### PR TITLE
Service: print HTML

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict
+from typing import Union, Dict, Optional
 from pydantic import BaseModel
 import uvicorn
 from enum import Enum
@@ -20,8 +20,8 @@ class PrintFormat(str, Enum):
 class PrintPayload(BaseModel):
     type: PrintType
     format: PrintFormat
-    filename: str
     context: Dict = {}
+    filename: Optional[str] = None
 
 @app.post("/print")
 async def handle_print(

--- a/main.py
+++ b/main.py
@@ -1,44 +1,58 @@
 from typing import Union, Dict
 from pydantic import BaseModel
 import uvicorn
+from enum import Enum
 from fastapi import FastAPI, Request, Response, HTTPException, Body
 from fastapi.templating import Jinja2Templates
-from playwright.sync_api import sync_playwright
+# from playwright.sync_api import sync_playwright
 
 app = FastAPI()
 
 templates = Jinja2Templates(directory="templates")
 
-def parse_html(request: Request, file_name: str, context: Dict):
-    return templates.TemplateResponse(name=file_name, context={ "request": request, **context })
+class PrintType(str, Enum):
+    Debug = 'debug'
 
-class Context(BaseModel):
-    context: Dict
+class PrintFormat(str, Enum):
+    HTML = "html"
+    PDF = "pdf"
 
-@app.post('/print')
-async def print(
-   request: Request,
-   body: Dict = Body(...)
+class PrintPayload(BaseModel):
+    type: PrintType
+    format: PrintFormat
+    filename: str
+    context: Dict = {}
+
+@app.post("/print")
+async def handle_print(
+    request: Request,
+    body: PrintPayload = Body(...)
 ):
     try:
-      parsed_html = parse_html(request=request, file_name='index.html', context=body)
+        templates_dir = Jinja2Templates(directory='./templates')
+        template_file = templates_dir.get_template(name=f"{body.type}.html")
 
-      with sync_playwright() as playwright:
-        webkit = playwright.webkit
-        browser = webkit.launch()
-        context = browser.new_context()
-        page = context.new_page()
-        page.set_content(parsed_html.body)
+        # for debugging
+        context = body.context
+        if (body.type == PrintType.Debug):
+            context = { 'context': body.context }
 
-        pdf = page.pdf()
-        browser.close()
-
-        # Return API response with pdf type
-        return Response(content=pdf, media_type="application/pdf")
-
+        html_content = template_file.render({
+            'request': request,
+            **context,
+        })
+        
+        if (body.format == PrintFormat.HTML):
+            return Response(
+                content=html_content,
+                headers={
+                    'content-type': 'text/html',
+                }
+            )
+        raise TypeError('invalid format')
     except Exception as e:
-      raise HTTPException(status_code=500, detail=str(e))
-    
+        raise HTTPException(status_code=500, detail=str(e))
+
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="localhost", port=8000)
+    uvicorn.run('main:app', host="localhost", port=8000, reload=True)

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ class PrintPayload(BaseModel):
     type: PrintType
     format: PrintFormat
     context: Dict = {}
-    filename: Optional[str] = None
+    filename: str
 
 @app.post("/print")
 async def handle_print(
@@ -39,6 +39,7 @@ async def handle_print(
 
         html_content = template_file.render({
             'request': request,
+            'filename': body.filename,
             **context,
         })
         

--- a/main.py
+++ b/main.py
@@ -15,8 +15,8 @@ def parse_html(request: Request, file_name: str, context: Dict):
 class Context(BaseModel):
     context: Dict
 
-@app.post('/pdf')
-async def generate_pdf(
+@app.post('/print')
+async def print(
    request: Request,
    body: Dict = Body(...)
 ):

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Document</title>
+  <title>{{ filename if filename else 'Document' }}</title>
 </head>
 <body>
   <h1>

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -6,6 +6,11 @@
   <title>Document</title>
 </head>
 <body>
-  Generate PDF
+  <h1>
+    Blank Page
+  </h1>
+  <code>
+    {{ context | safe }}
+  </code>
 </body>
 </html>


### PR DESCRIPTION
### Changes
- Rename endpoint `/pdf` to `/print`
- Create service for compiling HTML template

### Print Payload Schema
```typescript
{
   type: 'debug', // 'debug', 'stay-voucher', 'flight-voucher', etc
   format: 'html', // 'html', 'pdf'
   filename: string,
   context: {} // any object
}
```

### How to Test
1. Run `python main.py`
2. Request to `http://localhost:8000/print` with this payload
    ```json5
    {
      type: 'debug',
      format: 'html',
      filename: 'My filename', // or any name
      context: {} // put anything in this object
    }
    ```
3. Any object put in `context` will appear in the generated HTML file

### Test Result
**Positive Case: Valid Payload**
| <img width="480" alt="Screenshot 2023-08-12 at 16 08 43" src="https://github.com/amardevsingh98/python-html-to-pdf/assets/20709202/7fde6a48-67f2-40f2-ada9-313693037824"> |
| --- |

**Negative Case: Invalid Payload**
| <img width="480" alt="Screenshot 2023-08-12 at 16 10 47" src="https://github.com/amardevsingh98/python-html-to-pdf/assets/20709202/c9045fa6-8028-478b-b827-4632866280b3"> |
| --- |


