### PR TITLE
Improve: payload and filters

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
-from typing import Union, Dict, Optional
-from pydantic import BaseModel
 import uvicorn
+import utils
+
+from inspect import getmembers, isfunction
+from typing import Dict
+from pydantic import BaseModel
 from enum import Enum
 from fastapi import FastAPI, Request, Response, HTTPException, Body
 from fastapi.templating import Jinja2Templates
@@ -20,8 +23,10 @@ class PrintFormat(str, Enum):
 class PrintPayload(BaseModel):
     type: PrintType
     format: PrintFormat
-    context: Dict = {}
     filename: str
+    data: Dict = {}
+    header: Dict = {}
+    footer: Dict = {}
 
 @app.post("/print")
 async def handle_print(
@@ -30,29 +35,33 @@ async def handle_print(
 ):
     try:
         templates_dir = Jinja2Templates(directory='./templates')
+        templates_dir.env.globals = {
+            **templates_dir.env.globals,
+            **(dict(getmembers(utils, isfunction)))
+        }
         template_file = templates_dir.get_template(name=f"{body.type}.html")
-
-        # for debugging
-        context = body.context
-        if (body.type == PrintType.Debug):
-            context = { 'context': body.context }
 
         html_content = template_file.render({
             'request': request,
             'filename': body.filename,
-            **context,
+            'data': body.data,
+            'header': body.header,
+            'footer': body.footer,
         })
         
         if (body.format == PrintFormat.HTML):
+            filename = body.filename if body.filename.endswith('.html') else f"{body.filename}.html"
             return Response(
                 content=html_content,
                 headers={
                     'content-type': 'text/html',
+                    'content-disposition': 'Attachment',
+                    'filename': filename
                 }
             )
         if (body.format == PrintFormat.PDF):
             pdf_content = None
-            pdf_filename = body.filename if body.filename.endswith('.pdf') else f"{body.filename}.pdf"
+            filename = body.filename if body.filename.endswith('.pdf') else f"{body.filename}.pdf"
             async with async_api.async_playwright() as p:
                 browser = await p.chromium.launch(
                     headless=True
@@ -68,7 +77,7 @@ async def handle_print(
                     headers={
                         'content-type': 'application/pdf',
                         'content-disposition': 'Attachment',
-                        'filename': pdf_filename
+                        'filename': filename
                     }
                 )
         raise TypeError('invalid format')

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -10,7 +10,11 @@
     Blank Page
   </h1>
   <code>
-    {{ context | safe }}
+    {{ {
+      'header': header,
+      'footer': footer,
+      'data': data
+    } }}
   </code>
 </body>
 </html>


### PR DESCRIPTION
### Description
Previously all needed data is put under `context`, including `headerLogo`, `showDownloadApp` section.
For better predictability, data is now separated into:
```json5
{
   data: Dict, // data needed for the template, e.g booking data
   header: Dict, // config for header, e.g logo
   footer: Dict, // config for footer, e.g show download app section
}
```

### Payload Schema
```typescript
{
   data: any;
   header: {
      logo_src: string;
      logo_alt: string;
   };
   footer: {
     show_download_app: boolean;
   }
}
```

### How to Test
- Same test as #2 and #3

    1. Go to project dir
    2. Run this project `source venv/bin/activate && pip install && python main.py`
    3. Make request to `http://localhost:8000/print` with this payload:
        ```json5
        {
          "type": "debug",
          "format": "html",
          "filename": "Voucher Booking #838680",
          "data": {
            "foo": "bar",
            "quux": "baz"
          },
          "header": {
            "logo_src": "https://cdn.wisata.app/f/52ee9453-c8c7-452d-9457-7674df571c8f.jpeg",
            "logo_alt": ""
          },
          "footer": {
            "show_download_app": true
          }
        }
        ```
    4. All given data must appear in the generated HTML/PDF.
    
### Test Result
**HTML**
| |
| --- |
| <img width="600" alt="Screenshot 2023-08-14 at 05 07 19" src="https://github.com/amardevsingh98/python-html-to-pdf/assets/20709202/8cff351d-eba9-48bb-82e0-63ee19a6b9da"> |
| <img width="600" alt="Screenshot 2023-08-14 at 05 07 10" src="https://github.com/amardevsingh98/python-html-to-pdf/assets/20709202/dea4cc90-ef09-4b17-b0da-1f564da81bc1"> |

PDF
| <img width="600" alt="Screenshot 2023-08-14 at 05 07 48" src="https://github.com/amardevsingh98/python-html-to-pdf/assets/20709202/6dd67db8-cee2-4564-9f7f-26e5c35844d9"> |
| --- |
