### PR TITLE
Templates: Wisata Bill

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ class PrintType(str, Enum):
     Debug = 'debug'
     StayVoucher = 'stay-voucher'
     WisataBill = 'wisata-bill'
+    PaymentTransactionsHistory = 'payment-transactions-history'
 
 class PrintFormat(str, Enum):
     HTML = "html"

--- a/main.py
+++ b/main.py
@@ -69,7 +69,14 @@ async def handle_print(
                 )
                 page = await browser.new_page()
                 await page.set_content(html_content)
-                pdf_content = await page.pdf()
+                pdf_content = await page.pdf(
+                    margin={
+                        'top': '2cm',
+                        'right': '1cm',
+                        'bottom': '1cm',
+                        'left': '1cm',
+                    }
+                )
                 await browser.close()
 
             if (pdf_content != None):

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ class PrintType(str, Enum):
     WisataBill = 'wisata-bill'
     PaymentTransactionsHistory = 'payment-transactions-history'
     StayInvoice = 'stay-invoice'
+    HotelVoucherVisaInvoice = 'hotel-voucher-visa-invoice'
 
 class PrintFormat(str, Enum):
     HTML = "html"

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ class PrintType(str, Enum):
     Debug = 'debug'
     StayVoucher = 'stay-voucher'
     WisataBill = 'wisata-bill'
+    FlightVoucher = 'flight-voucher'
 
 class PrintFormat(str, Enum):
     HTML = "html"

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ class PrintType(str, Enum):
     Debug = 'debug'
     StayVoucher = 'stay-voucher'
     WisataBill = 'wisata-bill'
-
+    OfflineBookingFlightInvoice = 'offline-booking-flight-invoice'
 class PrintFormat(str, Enum):
     HTML = "html"
     PDF = "pdf"

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ class PrintPayload(BaseModel):
     data: Dict = {}
     header: Dict = {}
     footer: Dict = {}
+    app_config: Dict = {}
 
 @app.post("/print")
 async def handle_print(
@@ -50,6 +51,7 @@ async def handle_print(
             'data': body.data,
             'header': body.header,
             'footer': body.footer,
+            'app_config': body.app_config,
         })
         
         if (body.format == PrintFormat.HTML):

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ class PrintType(str, Enum):
     StayVoucher = 'stay-voucher'
     WisataBill = 'wisata-bill'
     PaymentTransactionsHistory = 'payment-transactions-history'
+    StayInvoice = 'stay-invoice'
 
 class PrintFormat(str, Enum):
     HTML = "html"

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ class PrintType(str, Enum):
     Debug = 'debug'
     StayVoucher = 'stay-voucher'
     WisataBill = 'wisata-bill'
+    OfflineBookingCustomInvoice = 'offline-booking-custom-invoice'
 
 class PrintFormat(str, Enum):
     HTML = "html"

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ templates = Jinja2Templates(directory="templates")
 class PrintType(str, Enum):
     Debug = 'debug'
     StayVoucher = 'stay-voucher'
+    WisataBill = 'wisata-bill'
 
 class PrintFormat(str, Enum):
     HTML = "html"

--- a/templates/flight-voucher.html
+++ b/templates/flight-voucher.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link type="text/css" href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+  <style>
+    html {
+      font-size: 14px !important;
+    }
+ 
+    p {
+      margin: 0 !important;
+    }
+    table.table-bordered {
+      border-collapse: collapse;
+    }
+    table.table-bordered thead tr th {
+      border-top: 1px solid rgba(0,0,0,0.12);
+    }
+    table.table-bordered thead tr th:first-child {
+      border-left: 1px solid rgba(0,0,0,0.12);
+    }
+    table.table-bordered tbody tr td:first-child {
+      border-left: 1px solid rgba(0,0,0,0.12);
+    }
+    table.table-bordered th,
+    table.table-bordered td {
+      border-right: 1px solid rgba(0,0,0,0.12);
+      border-bottom: 1px solid rgba(0,0,0,0.12);
+    }
+    table.table-bordered th,
+    table.table-bordered td {
+      padding: 8px 16px;
+    }
+    .divider {
+      display: block;
+      border-top: 1px solid rgba(0,0,0,0.12);
+      width: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="v-application theme--light">
+    <div class="container text-body-1">
+      <section class="mb-2">
+        <p class="text-h5 font-weight-bold">
+          Flight Voucher
+        </p>
+      </section>
+
+      <section class="mb-8">
+        <table>
+          <tbody>
+            <tr class="pa-0" style="vertical-align: top;">
+              <td class="pa-0 pr-8">
+                <div class="mb-0 text-button text-uppercase" style="line-height: 1.25 !important; font-size: 10px;">
+                  Voucher ID
+                </div>
+                <div class="mb-0 text-body-1 font-weight-bold">
+                  {{ data.bookingId }}
+                </div>
+              </td>
+              <td class="pa-0 pr-8">
+                <div class="mb-0 text-button text-uppercase" style="line-height: 1.25 !important; font-size: 10px;">
+                  PNR
+                </div>
+                <div class="mb-0 text-body-1 font-weight-bold">
+                  {{ data.pnr }}
+                </div>
+              </td>
+              <td class="pa-0 pr-8">
+                <div class="text-button text-uppercase" style="line-height: 1.25 !important; font-size: 10px;">
+                  Itinerary ID
+                </div>
+                <div class="text-body-1 font-weight-bold">
+                  {{ data.order_number }}
+                </div>
+              </td>
+              <td class="pa-0 pr-8">
+                <div class="text-button text-uppercase" style="line-height: 1.25 !important; font-size: 10px;">
+                  Reserved For
+                </div>
+                <div class="text-body-1 font-weight-bold">
+                  {{ data.booker.name }}
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="mt-8">
+        <p class="mb-2 text-h6 font-weight-bold">
+          Flight Details
+          {% if data.direction == 'OW'%}
+            <span>| One Way</span>
+          {% elif data.direction == 'RT'%}
+            <span>| Round Trip</span>
+          {% endif %}
+        </p>
+        <div>
+          <table class="table-bordered" style="width: 100%;">
+            <tbody>
+              {% for item in data.provider_bookings %}
+                <tr>
+                  <td style="border-top: 1px solid rgba(0,0,0,0.12);">
+                    <div class="pr-2 d-flex align-center">
+                      <div
+                        class="theme--light v-sheet v-sheet--outlined d-flex justify-center align-center rounded-circle blue"
+                        style="width: 16px; height: 16px;"
+                      >
+                        <span class="white--text text-caption font-weight-medium">
+                          {{ item.sequence }}
+                        </span>
+                      </div>
+                      <div class="ml-3 text-body-1 font-weight-bold">
+                        {{ get(data.airportsMap, item.journeys.0.origin, 'city') }} - {{ get(data.airportsMap, item.journeys.0.destination, 'city') }}
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                
+                {% for segment in flight_get_all_segments_by_journey(item.journeys[0]) %}
+                  <tr style="vertical-align: top;">
+                    <td>
+                      <div class="row">
+                        <div class="col col-6 text-body-1">
+                          <div>
+                            <span class="font-weight-bold">
+                              {{ get_time_from_date(segment.departure_date) }}
+                            </span>
+                            · {{ get_day_from_date(segment.departure_date) }}, {{ udf_pretty_date(segment.departure_date) }}
+                          </div>
+                          <div>
+                            {{ get(data.airportsMap, segment.origin, 'name') }}
+                          </div>
+                          <div>
+                            {{ segment.carrier_name }} · {{ segment.carrier_code }} {{ segment.carrier_number }}
+                          </div>
+                        </div>
+                        <div class="col col-6 text-body-1">
+                          <div>
+                            <span class="font-weight-bold">
+                              {{ get_time_from_date(segment.arrival_date) }}
+                            </span>
+                            · {{ get_day_from_date(segment.arrival_date) }}, {{ udf_pretty_date(segment.arrival_date) }}
+                          </div>
+                          <div>
+                            {{ get(data.airportsMap, segment.destination, 'name') }}
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                {% endfor %}
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="mt-8">
+        <p class="mb-2 text-h6 font-weight-bold">
+          Passenger Details
+        </p>
+        <table class="table-bordered" style="width: 100%;">
+          <thead>
+            <tr class="text-left text-overline text--secondary" style="vertical-align: top;">
+              <th>
+                No.
+              </th>
+              <th>
+                Name
+              </th>
+              <th>
+                Facilities
+              </th>
+              <th>
+                Ticket Number
+              </th>
+              <th class="text-right">
+                Price
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for passenger in data.passengers %}
+            <tr class="text-left" style="vertical-align: top; page-break-inside: avoid;">
+              <td>
+                <div
+                  class="theme--light v-sheet v-sheet--outlined d-flex justify-center align-center rounded-circle blue"
+                  style="width: 16px; height: 16px;"
+                >
+                  <span class="white--text text-caption font-weight-medium">
+                    {{loop.index}}
+                  </span>
+                </div>
+              </td>
+              <td>
+                {{ passenger.name }}
+              </td>
+              <td>
+                {{ flight_get_facilities_per_passenger(data.provider_bookings, passenger.passenger_number)|safe }}
+              </td>
+              <td>
+                {{ flight_get_ticket_number(data.provider_bookings, passenger.passenger_number) }}
+              </td>
+              <td class="text-right text-no-wrap">
+                {{ udf_format_currency(flight_get_total_fees_per_passenger(data.pnr, data.passengers, passenger.passenger_number)) }}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </section>
+
+      <section class="mt-8">
+        <p class="mb-2 text-h6 font-weight-bold">
+          Important Notes
+        </p>
+        <ul style="margin-left: -0.5em;">
+          <li>
+            <p>
+              Please arrive at the airport 90 minutes before domestic flight and 2 hours before international flight.
+            </p>
+          </li>
+          <li>
+            <p>
+              Passengers agree with Terms and Conditions of Carriage outlined by Carrier.
+            </p>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </div>
+  <div class="v-application theme--light">
+    <div class="container">
+      <div class="text-body-2" style="width: 100%; padding-top: 96px;">
+        {% include 'footer.html' %}
+      </div>
+    </div>
+  </div>
+
+</body>
+
+</html>

--- a/templates/flight-voucher.html
+++ b/templates/flight-voucher.html
@@ -133,7 +133,7 @@
                             <span class="font-weight-bold">
                               {{ get_time_from_date(segment.departure_date) }}
                             </span>
-                            · {{ get_day_from_date(segment.departure_date) }}, {{ udf_pretty_date(segment.departure_date) }}
+                            · {{ get_day_from_date(segment.departure_date) }}, {{ udf_pretty_date(segment.departure_date, include_year=True) }}
                           </div>
                           <div>
                             {{ get(data.airportsMap, segment.origin, 'name') }}
@@ -147,7 +147,7 @@
                             <span class="font-weight-bold">
                               {{ get_time_from_date(segment.arrival_date) }}
                             </span>
-                            · {{ get_day_from_date(segment.arrival_date) }}, {{ udf_pretty_date(segment.arrival_date) }}
+                            · {{ get_day_from_date(segment.arrival_date) }}, {{ udf_pretty_date(segment.arrival_date, include_year=True) }}
                           </div>
                           <div>
                             {{ get(data.airportsMap, segment.destination, 'name') }}

--- a/templates/hotel-voucher-visa-invoice.html
+++ b/templates/hotel-voucher-visa-invoice.html
@@ -1,0 +1,511 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+  xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title>
+
+  </title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+    footer p {
+      line-height: 1 !important;
+      margin: 0 !important;
+      font-family: Roboto, system-ui !important;
+    }
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet"
+    type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap);
+  </style>
+  <!--<![endif]-->
+
+
+
+  <style type="text/css">
+
+
+  </style>
+  <style type="text/css">
+    html {
+      scrollbar-width: none;
+      color: #121212;
+    }
+
+    html * {
+      font-size: 13px;
+      font-family: -apple-system, BlinkMacSystemFont, Roboto, system-ui, sans-serif;
+    }
+
+    ::-webkit-scrollbar {
+      display: none !important;
+    }
+
+    .body {
+      padding-top: 3rem;
+      padding-bottom: 3rem;
+    }
+
+    .page-title-and-logo {
+      margin-top: 24px;
+      margin-bottom: 12px;
+      position: relative;
+      display: flex;
+      flex-flow: row nowrap;
+      align-items: center;
+    }
+
+    .header-logo {
+      max-width: 160px;
+      max-height: 72px;
+      object-fit: contain;
+      float: right;
+    }
+
+    table th,
+    table td {
+      vertical-align: top !important;
+    }
+
+    table.table-invoice-header {
+      line-height: 1.25;
+      width: auto !important;
+    }
+
+    table.table-invoice-order {
+      line-height: 1.5;
+      display: block !important;
+      width: 960px;
+    }
+
+    table.table-invoice-header thead tr th,
+    table.table-invoice-header tbody tr td {
+      padding: 0.25rem 1.5rem 0.25rem 0;
+    }
+
+    table.table-invoice-order thead tr th,
+    table.table-invoice-order tbody tr td {
+      padding: 0.5rem;
+    }
+
+    table.table-invoice-order thead tr th {
+      border-top: 2px solid #212121;
+      border-bottom: 2px solid #212121;
+    }
+
+    table.table-invoice-order thead tr th:first-child,
+    table.table-invoice-order tbody tr:first-child td:first-child {
+      xborder-left: 3px solid #212121;
+    }
+
+    table.table-invoice-order tbody tr:first-child td {
+      border-bottom: 3px solid #EAEAEA;
+    }
+
+    table.table-invoice-order thead tr th:last-child,
+    table.table-invoice-order tbody tr td:last-child {
+      xborder-right: 2px solid #212121;
+    }
+
+    table.table-invoice-order tbody tr:nth-child(n+2) td:first-child {
+      xborder-right: 3px solid #EAEAEA;
+    }
+
+    table.table-invoice-order tbody tr:nth-child(n+2) td:nth-child(n+3) {
+      border-bottom: 1px solid #EAEAEA;
+    }
+
+    table.table-invoice-order tbody tr:last-child td:nth-child(n+3) {
+      border-bottom: 2px solid #424242;
+    }
+
+    table td.border-b-0 {
+      border-bottom: none !important;
+    }
+
+    .text-no-wrap {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .text-red {
+      color: #f44336;
+    }
+
+    .text-grey {
+      color: #b2b2b2;
+    }
+
+    .text-left {
+      text-align: left;
+    }
+
+    .text-right {
+      text-align: right;
+    }
+
+    .text--secondary {
+      color: #808080;
+    }
+
+    .text-h5 {
+      font-size: 1.375rem;
+    }
+
+    .text-h6 {
+      font-size: 1.25rem;
+    }
+
+    .text-h7 {
+      font-size: 1.125rem;
+    }
+
+    .font-weight-medium {
+      font-weight: 500 !important;
+    }
+
+    .font-weight-bold {
+      font-weight: 700 !important;
+    }
+
+    .price-breakdown-grid {
+      display: grid;
+      grid-template-columns: minmax(8ch, auto) minmax(8ch, auto) 1fr;
+      gap: 0 0.5rem;
+    }
+
+    .price-breakdown-grid>* {
+      line-height: 1.375 !important;
+      font-size: 12px !important;
+    }
+  </style>
+
+</head>
+
+<body style="word-spacing:normal;">
+
+
+  <div style>
+
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+      <tbody>
+        <tr>
+          <td>
+
+
+            <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+            <div style="margin:0px auto;max-width:960px;">
+
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                <tbody>
+                  <tr>
+                    <td style="direction:ltr;font-size:0px;padding:0px;text-align:left;">
+                      <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><![endif]-->
+
+                      <div>
+                        <div class="page-title-and-logo">
+                          <div id="invoice-{{ data.booking_id }}" class="text-h5 font-weight-bold">
+                            Invoice
+                          </div>
+                          <img src="{{ header.logo_src }}" alt class="header-logo" style="position: absolute; right: 0;">
+                        </div>
+                        <table class="table-invoice-header">
+                          <tbody>
+                            <tr>
+                              <td>
+                                Number
+                              </td>
+                              <td style="padding-right: 0.5rem !important;">
+                                :
+                              </td>
+                              <td>
+                                {{ data.booking_id }}
+                              </td>
+                            </tr>
+                            <tr>
+                              <td class="text-no-wrap">
+                                Booking Date
+                              </td>
+                              <td style="padding-right: 0.5rem !important;">
+                                :
+                              </td>
+                              <td>
+                                {{ udf_pretty_date(data.created_date, null, true) }}
+                              </td>
+                            </tr>
+                            <tr>
+                              <td colspan="3" class="font-weight-bold">
+                                <div style="margin-top: 16px;">
+                                  BILL TO
+                                </div>
+                              </td>
+                              <td>
+                                <div style="min-width: 48px;"></div>
+                              </td>
+                              <td colspan="3" class="font-weight-bold">
+                                <div style="margin-top: 16px;">
+                                  TRAVELERS
+                                </div>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>
+                                Customer
+                              </td>
+                              <td style="padding-right: 0.5rem !important;">
+                                :
+                              </td>
+                              <td>
+                                {{ data.owner_data.name }}
+                              </td>
+                              <td></td>
+                              <td>
+                                Name
+                              </td>
+                              <td style="padding-right: 0.5rem !important;">
+                                :
+                              </td>
+                              <td rowspan="3">
+                                <div style="max-width: 320px;">
+                                  {{ data.guest_order_data.guest_data[0].full_name }}
+                                </div>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>
+                                Email
+                              </td>
+                              <td style="padding-right: 0.5rem !important;">
+                                :
+                              </td>
+                              <td>
+                                {% if data.owner_data.email %}
+                                {{ data.owner_data.email }}
+                                {% else %}
+                                -
+                                {% endif %}
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>
+                                Phone
+                              </td>
+                              <td style="padding-right: 0.5rem !important;">
+                                :
+                              </td>
+                              <td>
+                                {% if data.owner_data.phone %}
+                                {{ data.owner_data.phone }}
+                                {% else %}
+                                -
+                                {% endif %}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <div class="font-weight-bold" style="margin-top: 24px; margin-bottom: 0.75em;">
+                          ORDER DETAILS
+                        </div>
+                        <table class="table-invoice-order" style="width: 100%;">
+                          <thead>
+                            <tr>
+                              <th class="font-weight-bold text-left">
+                                Accomodation
+                              </th>
+                              <th class="font-weight-bold text-right">
+                                Quantity
+                              </th>
+                              <th class="font-weight-bold text-left" style="width: 1%;">
+                                Details
+                              </th>
+                              <th class="font-weight-bold text-right" style="width: 1%; min-width: 120px;">
+                                Subtotal (Rp)
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>
+                                <div style="line-height: 1.5;">
+                                  {{ data.product_data.name_1 }}
+                                </div>
+                                <div style="line-height: 1.5;">
+                                  {{ udf_pretty_date(data.dates_data.start_date, data.dates_data.end_date, true) }}
+                                </div>
+                                <div style="line-height: 1.5;">
+                                  <span>
+                                    {{ data.product_data.name_2 }}
+                                  </span>
+                                </div>
+                              </td>
+                              <td class="text-right">
+                                {{ data.quantity }}
+                              </td>
+                              <td>
+                                <div class="text--secondary">
+                                  -
+                                </div>
+                              </td>
+                              <td class="monospace text-right font-weight-bold"
+                                style="font-family: Courier, monospace;">
+                                {{ udf_format_currency(data.draft_price, 'skip') }}
+                              </td>
+                            </tr>
+
+                            {% for pb in data.price_breakdown %}
+                            {% if pb.type_code != 'BO' %}
+                            <tr>
+                              <td></td>
+                              <td></td>
+                              {% if pb.type == 'CBX' and pb.amount > 0 %}
+                              <td class="text-red">
+                                {% elif pb.type == 'CCL' %}
+                              </td>
+                              <td class="text-red">
+                                {% elif pb.type == 'RFND' %}
+                              </td>
+                              <td class="text-red">
+                                {% else %}
+                              </td>
+                              <td>
+                                {% endif %}
+                                <div style="min-width: 200px;">
+                                  {{ pb.type_description }} {{ ('(' + pb.note + ')') if pb.note else '' }}
+                                  {% if pb.type in ['CCL', 'RFND', 'ADJ'] %}
+                                  <span style="display: inline-block;">
+                                    (on {{ udf_pretty_date(pb.txn_dt, null, true) }})
+                                  </span>
+                                  {% endif %}
+                                </div>
+                              </td>
+
+                              {% if pb.type == 'CBX' and pb.amount > 0 %}
+                              <td class="monospace text-right text-red font-weight-bold"
+                                style="font-family: Courier, monospace;">
+                                {% elif pb.type == 'CCL' %}
+                              </td>
+                              <td class="monospace text-right text-red font-weight-bold"
+                                style="font-family: Courier, monospace;">
+                                {% elif pb.type == 'RFND' %}
+                              </td>
+                              <td class="monospace text-right text-red font-weight-bold"
+                                style="font-family: Courier, monospace;">
+                                {% else %}
+                              </td>
+                              <td class="monospace text-right font-weight-bold"
+                                style="font-family: Courier, monospace;">
+                                {% endif %}
+                                {{ udf_format_currency(pb.amount, 'skip') }}
+                              </td>
+                            </tr>
+                            {% endif %}
+                            {% endfor %}
+                            <tr>
+                              <td></td>
+                              <td></td>
+                              <td class="font-weight-bold">
+                                Total
+                              </td>
+                              <td class="monospace text-right font-weight-bold"
+                                style="font-family: Courier, monospace;">
+                                {{ udf_format_currency(data.final_price) }}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+
+                      <!--[if mso | IE]></table><![endif]-->
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+
+            </div>
+
+
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+
+
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+  {% if (app_config.app.tenant_name == 'wisatajawa') and (data.paymentMethod == 'BILL') %}
+  <div style="margin-top: 32px;"></div>
+  <div class="roboto">
+    <div style="line-height: 1.5; font-size: 14px; font-family: Roboto, system-ui;">
+      Rekening BCA<br>
+      AN. PT WISATA JAWA INDAH<br>
+      AC. 1035599888
+    </div>
+  </div>
+  {% endif %}
+  {% if (app_config.app.tenant_name == 'wisatajawa') and (footer.show_download_app) %}
+  <div style="padding-top: 100px;">
+  </div>
+  {% include 'footer.html' %}
+  {% endif %}
+
+</body>
+
+</html>

--- a/templates/offline-booking-custom-invoice.html
+++ b/templates/offline-booking-custom-invoice.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link type="text/css" href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+  <style>
+    html {
+      font-size: 14px !important;
+    }
+
+    p {
+      margin: 0 !important;
+    }
+
+    .header-grid {
+      display: grid;
+      grid-template-columns: auto auto 1fr;
+      gap: 0 1rem;
+    }
+
+    .table-invoice {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid;
+      table-layout: fixed;
+    }
+
+    .table-invoice th,
+    .table-invoice td {
+      padding: 0.5em 1em;
+      background-color: white;
+    }
+
+    .table-invoice tbody th,
+    .table-invoice tbody td {
+      border-top: 1px solid;
+      border-color: inherit;
+    }
+
+    .table-invoice tbody tr:last-child td {
+      border-bottom: 1px solid;
+      border-color: inherit;
+    }
+
+    img.header-logo {
+      max-height: 72px;
+      max-width: 160px;
+    }
+
+    footer {
+      margin-top: 100px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="v-application theme--light">
+    <div class="container text-body-2">
+      <header>
+        <div class="d-flex justify-space-between">
+          <div>
+            <p class="text-h6">
+              <strong>Invoice #{{ data.booking_id }}</strong>
+            </p>
+            {% if data.issue_data and data.issue_data.issue_id %}
+            <div>
+              {{ data.issue_data.subject }} ({{ data.issue_data.status }})
+            </div>
+            {% endif %}
+            <div class="mt-4 header-grid">
+              <div>Tanggal Invoice</div>
+              <span>:</span>
+              <p><strong>{{udf_pretty_date(data.created_date, include_year=True)}}</strong></p>
+
+              <div>Jatuh Tempo</div>
+              <span>:</span>
+              <p><strong>{{udf_pretty_date(data.created_date, include_year=True)}}</strong></p>
+
+              <div>Pembayaran</div>
+              <span>:</span>
+              <p><strong>CREDIT</strong></p>
+            </div>
+          </div>
+          <div class="text-right">
+            {% if header and header.logo_src %}
+            <img
+              src="{{ header.logo_src }}"
+              class="header-logo"
+            >
+            {% endif %}
+          </div>
+        </div>
+      </header>
+
+      <main class="mt-8">
+        <div class="font-weight-bold">
+          CUSTOMER: {{ data.on_behalf_user_account_name }}
+        </div>
+
+        <table class="table-invoice table-fixed grey lighten-2 mt-2">
+          <thead>
+            <tr class="text-left">
+              <th style="width: 10px !important">No</th>
+              <th>Nama Produk</th>
+              <th style="width: 30% !important">Detail Produk</th>
+              <th class="text-center">Kuantitas</th>
+              <th class="text-right">Jumlah IDR</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in data.guest_order_data.order_data %}
+            <tr>
+              <td class="text-right">{{loop.index}}</td>
+              <td class="text-capitalize">{{item.item_name}}</td>
+              <td>{{item.item_detail}}</td>
+              <td class="text-center">{{item.quantity}}</td>
+              <td class="text-right text-no-wrap">{{udf_format_currency(item.price)}}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+          <tfoot>
+            {% for price_data in price_breakdown %}
+            <tr>
+              {% if price_data.type_code != 'BO' %}
+              <td colspan="3"></td>
+              <td class="text-center">
+                {{price_data.type_description}} {{price_data.note}}
+              </td>
+              <td class="text-right text-no-wrap">{{udf_format_currency(price_data.amount)}}</td>
+              {% endif %}
+            </tr>
+            {% endfor %}
+            <tr class="font-weight-bold">
+              <td colspan="3"></td>
+              <td class="text-center">Total</td>
+              <td class="text-right text-no-wrap">{{udf_format_currency(data.final_price) }}</td>
+            </tr>
+          </tfoot>
+        </table>
+
+        <div class="mt-8">
+          <div class="d-flex align-end">
+            <p>
+              Rekening BCA<br>
+              AN. PT WISATA JAWA INDAH<br>
+              AC. 829.090.8770
+            </p>
+            <i class="spacer"></i>
+            <div class="mr-6">
+              {{data.created_by}}
+            </div>
+            <div class="mr-6 text-center">
+              <p class="mb-12">Diterima oleh,</p>
+              <span>(______________)</span>
+            </div>
+            <div class="mr-6 text-center">
+              <p class="mb-12">Disetujui oleh,</p>
+              <span>(______________)</span>
+            </div>
+          </div>
+        </div>
+      </main>
+      
+      {% include 'footer.html' %}
+    </div>
+  </div>
+
+</body>
+
+</html>

--- a/templates/offline-booking-flight-invoice.html
+++ b/templates/offline-booking-flight-invoice.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link type="text/css" href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+  <style>
+    html {
+      font-size: 14px !important;
+    }
+
+    p {
+      margin: 0 !important;
+    }
+
+    .header-grid {
+      display: grid;
+      grid-template-columns: auto auto 1fr;
+      gap: 0 1rem;
+    }
+
+    .table-invoice {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid;
+    }
+
+    .table-invoice th,
+    .table-invoice td {
+      padding: 0.5em 1em;
+      background-color: white;
+    }
+
+    .table-invoice tbody th,
+    .table-invoice tbody td {
+      border-top: 1px solid;
+      border-color: inherit;
+    }
+
+    .table-invoice tbody tr:last-child td {
+      border-bottom: 1px solid;
+      border-color: inherit;
+    }
+
+    img.header-logo {
+      max-height: 72px;
+      max-width: 160px;
+    }
+
+    footer {
+      margin-top: 100px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="v-application theme--light">
+    <div class="container text-body-2">
+      <header>
+        <div class="d-flex justify-space-between">
+          <div>
+            <p class="text-h6">
+              <strong>Invoice #{{ data.booking_id }}</strong>
+            </p>
+            {% if data.issue_data and data.issue_data.issue_id %}
+            <div>
+              {{ data.issue_data.subject }} ({{ data.issue_data.status }})
+            </div>
+            {% endif %}
+            <div class="mt-4 header-grid">
+              <div>Tanggal Invoice</div>
+              <span>:</span>
+              <p><strong>{{udf_pretty_date(data.created_date, include_year=True)}}</strong></p>
+
+              <div>Jatuh Tempo</div>
+              <span>:</span>
+              <p><strong>{{udf_pretty_date(data.created_date, include_year=True)}}</strong></p>
+
+              <div>Pembayaran</div>
+              <span>:</span>
+              <p><strong>CREDIT</strong></p>
+            </div>
+          </div>
+          <div class="text-right">
+            {% if header and header.logo_src %}
+            <img
+              src="{{ header.logo_src }}"
+              class="header-logo"
+            >
+            {% endif %}
+          </div>
+        </div>
+      </header>
+
+      <main class="mt-8">
+        <div class="font-weight-bold">
+          CUSTOMER: {{ data.on_behalf_user_account_name }}
+        </div>
+
+        <table class="table-invoice grey lighten-2 mt-2">
+          <thead>
+            <tr class="text-left">
+              <th class="text-right">No</th>
+              <th>Ticket Number</th>
+              <th>Nama Pax</th>
+              <th>Keterangan</th>
+              <th class="text-right">Jumlah IDR</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for order_data in data.guest_order_data.order_data %}
+            <tr>
+              <td class="text-right">{{loop.index}}</td>
+              <td>{{order_data.ticket_no}}</td>
+              <td>{{order_data.pax}}</td>
+              <td class="text-no-wrap">{{order_data.route_schedule}}</td>
+              <td class="text-right text-no-wrap">{{udf_format_currency(order_data.price)}}</td>
+            </tr>
+            {% endfor %}
+
+            {% for price_data in data.price_breakdown %}
+            <tr>
+              {% if price_data.type_code != 'BO' %}
+              <td colspan="3"></td>
+              <td>
+                {{price_data.type_description}} {{price_data.note}}
+              </td>
+              <td class="text-right text-no-wrap">{{udf_format_currency(price_data.amount)}}</td>
+              {% endif %}
+            </tr>
+            {% endfor %}
+            <tr class="font-weight-bold">
+              <td colspan="3"></td>
+              <td>Totals</td>
+              <td class="text-right text-no-wrap">{{udf_format_currency(data.final_price)}}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="d-flex align-end mt-8" style="page-break-inside: avoid; break-inside: avoid;">
+          <p>
+            Rekening BCA<br>
+            AN. PT WISATA JAWA INDAH<br>
+            AC. 829.090.8770
+          </p>
+          <i class="spacer"></i>
+          <div class="mr-6">
+            {{data.created_by}}
+          </div>
+          <div class="mr-6 text-center">
+            <p class="mb-12">Diterima oleh,</p>
+            <span>(______________)</span>
+          </div>
+          <div class="mr-6 text-center">
+            <p class="mb-12">Disetujui oleh,</p>
+            <span>(______________)</span>
+          </div>
+        </div>
+      </main>
+
+      {% include 'footer.html' %}
+    </div>
+  </div>
+
+</body>
+
+</html>

--- a/templates/payment-transactions-history.html
+++ b/templates/payment-transactions-history.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link type="text/css" href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+  <style>
+    html {
+      font-size: 14px !important;
+    }
+
+    p {
+      margin: 0 !important;
+    }
+
+    .text-break-all {
+      word-break: break-all;
+    }
+
+    .table-query td:nth-child(2)::before {
+      content: ':';
+      margin: 0 1em;
+    }
+
+    .table-history {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid #eee;
+    }
+
+    .table-history th,
+    .table-history td {
+      padding: 1em;
+      vertical-align: top;
+      background-color: white;
+    }
+
+    .table-history thead th,
+    .table-history thead td {
+      padding: 0.5em 1em;
+    }
+
+    .table-history tbody th,
+    .table-history tbody td {
+      border-top: 1px solid #eee;
+    }
+
+    .txn-items {
+      display: grid;
+      grid-template-columns: 2fr 2fr 6fr;
+      gap: 2rem;
+    }
+
+    img.header-logo {
+      max-height: 72px;
+      max-width: 160px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="v-application theme--light">
+    <div class="container text-body-2">
+      <header>
+        <p class="d-flex align-center mb-4 text-h5">
+          <strong>Transactions History - {{ data.query.year_month }}</strong>
+          <i class="spacer"></i>
+          {% if header and header.logo_src %}
+          <img
+            src="{{ header.logo_src }}"
+            class="header-logo"
+          >
+          {% endif %}
+        </p>
+
+        <p class="text-h6">
+          <strong>{{ data.query.customer_name }}</strong>
+        </p>
+        <table class="table-query">
+          <tbody>
+            <tr>
+              <td>Payment</td>
+              <td>
+                <strong>{{ data.query.method_name }}</strong>
+              </td>
+            </tr>
+            <tr>
+              <td>Transaction Type</td>
+              <td>
+                <strong style="text-transform: uppercase;">
+                  {{ data.query.txn_type }}
+                </strong>
+              </td>
+            </tr>
+            <tr>
+              <td>Total</td>
+              <td>
+                <strong>{{ data['items']|length }} transaction(s)</strong>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </header>
+
+      <main>
+        <table class="table-history mt-4 text-left">
+          <thead>
+            <tr>
+              <th>No</th>
+              <th colspan="2">Transaction</th>
+              <th class="text-right">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in data['items'] %}
+              <tr>
+                <td class="text-left">
+                  {{ loop.index }}
+                </td>
+                <td>
+                  <strong>{{ item.txn_data.txn_title }}</strong>
+                  <br>
+                  <span class="text-no-wrap text-caption">
+                    {{ udf_pretty_date(item.txn_date, include_year=True) }}
+                  </span>
+                </td>
+                <td>
+                  <p>
+                    {% if udf_txn_booking_id(item.txn_data) != None %}
+                      Booking ID {{ udf_txn_booking_id(item.txn_data) }}
+                    {% else %}
+                      {{ item.txn_data.txn_subtitle }}
+                    {% endif %}
+                  </p>
+                  <p class="text-caption text--disabled">
+                    {{ item.txn_data.txn_description }}
+                  </p>
+
+                  {% for txn_item in item.txn_data.txn_items %}
+                  <div class="txn-items mt-4 text-caption">
+                    <span>
+                      {{ txn_item.type_description }}
+                    </span>
+                    <span class="text-no-wrap">
+                      {{ udf_format_currency(txn_item.txn_item_amount) }}
+                    </span>
+                    <p class="text-break-all">
+                      {{ txn_item.note }}
+                    </p>
+                  </div>
+                  {% endfor %}
+
+                </td>
+                <td
+                  class="text-no-wrap text-right"
+                >
+                  <strong>
+                    {{ udf_format_currency(item.amount) }}
+                  </strong>
+                  <br>
+                  <span class="text-caption text--disabled">
+                    {{ udf_format_currency(item.rolling_amount) }}
+                  </span>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </main>
+    </div>
+  </div>
+
+</body>
+
+</html>

--- a/templates/stay-invoice.html
+++ b/templates/stay-invoice.html
@@ -1,0 +1,649 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+  xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title>
+
+  </title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+
+  <!--[if !mso]><!-->
+  <link type="text/css" href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet"
+    type="text/css">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet"
+    type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap);
+    @import url(https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500&display=swap);
+  </style>
+  <!--<![endif]-->
+
+
+
+  <style type="text/css">
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+
+      .mj-column-per-50 {
+        width: 50% !important;
+        max-width: 50%;
+      }
+
+      .mj-column-per-60 {
+        width: 60% !important;
+        max-width: 60%;
+      }
+
+      .mj-column-per-40 {
+        width: 40% !important;
+        max-width: 40%;
+      }
+    }
+  </style>
+  <style media="screen and (min-width:480px)">
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+
+    .moz-text-html .mj-column-per-50 {
+      width: 50% !important;
+      max-width: 50%;
+    }
+
+    .moz-text-html .mj-column-per-60 {
+      width: 60% !important;
+      max-width: 60%;
+    }
+
+    .moz-text-html .mj-column-per-40 {
+      width: 40% !important;
+      max-width: 40%;
+    }
+  </style>
+
+
+  <style type="text/css">
+    @media only screen and (max-width:480px) {
+      table.mj-full-width-mobile {
+        width: 100% !important;
+      }
+
+      td.mj-full-width-mobile {
+        width: auto !important;
+      }
+    }
+  </style>
+  <style type="text/css">
+    html {
+      scrollbar-width: none;
+    }
+
+    ::-webkit-scrollbar {
+      display: none !important;
+    }
+
+    .footer-content p {
+      line-height: 1 !important;
+      margin: 0 !important;
+      font-family: Roboto, system-ui !important;
+    }
+
+    .app-icon__container {
+      border: 1px solid #EEEEEE;
+      padding: 0px;
+      border-radius: 20%;
+      overflow: hidden;
+    }
+
+    .footer-content img {
+      box-sizing: border-box !important;
+    }
+    footer p {
+      margin: 0 !important;
+    }
+  </style>
+
+</head>
+
+<body style="word-spacing:normal;background-color:#FFFFFF;">
+
+
+  <div class="body"
+    style="padding: 20px; background-color: #FFFFFF; max-width: 960px; margin: auto; box-sizing: border-box;">
+
+
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+    <div style="margin:0px auto;max-width:960px;">
+
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:960px;" ><![endif]-->
+
+              <div class="mj-column-per-100 mj-outlook-group-fix"
+                style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;vertical-align:middle;">
+                <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:middle;width:480px;" ><![endif]-->
+
+                <div class="mj-column-per-50 mj-outlook-group-fix"
+                  style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:50%;">
+
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                    <tbody>
+                      <tr>
+                        <td style="vertical-align:middle;padding:0px;">
+
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                            <tbody>
+
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:0px;word-break:break-word;">
+
+                                  <div
+                                    style="font-family:Roboto, Arial, sans;font-size:22px;font-weight:500;line-height:150%;text-align:left;color:#000000;">
+                                    Invoice</div>
+
+                                </td>
+                              </tr>
+
+                              <tr>
+                                <td align="left" class="mj-table-customer mj-table-fixed align-baseline"
+                                  style="font-size:0px;padding:0px;word-break:break-word;">
+
+                                  <table cellpadding="0" cellspacing="0" width="100%" border="0"
+                                    style="color: #000000; font-family: Roboto, Arial, sans; font-size: 13px; line-height: 22px; border: none; table-layout: fixed; width: auto;">
+                                    <tr>
+                                      <td class="text-no-wrap"
+                                        style="white-space: nowrap; padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">
+                                        <div style="white-space: nowrap; vertical-align: baseline;">Number</div>
+                                      </td>
+                                      <td style="padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">{{ data.booking_id }}</td>
+                                    </tr>
+                                    <tr>
+                                      <td class="text-no-wrap"
+                                        style="white-space: nowrap; padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">
+                                        <div style="white-space: nowrap; vertical-align: baseline;">Issued date</div>
+                                      </td>
+                                      <td style="padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">{{ udf_pretty_date(data.created_date, null, true) }}</td>
+                                    </tr>
+                                  </table>
+
+                                </td>
+                              </tr>
+
+                            </tbody>
+                          </table>
+
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+
+                </div>
+
+                <!--[if mso | IE]></td><td style="vertical-align:top;width:480px;" ><![endif]-->
+
+                <div class="mj-column-per-50 mj-outlook-group-fix"
+                  style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;">
+
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                    <tbody>
+                      <tr>
+                        <td style="vertical-align:top;padding:0px;">
+
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                            <tbody>
+
+                              <tr>
+                                <td align="center" class="header-logo"
+                                  style="font-size:0px;padding:0px;word-break:break-word;">
+
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                    style="border-collapse:collapse;border-spacing:0px;">
+                                    <tbody>
+                                      <tr>
+                                        <td style="width:480px;">
+
+                                          <img alt height="auto" src="{{ header.logo_src }}"
+                                            style="max-width: 160px; max-height: 72px; object-fit: contain; float: right; border: 0; display: block; outline: none; text-decoration: none; height: auto; width: 100%; font-size: 13px;"
+                                            width="480">
+
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+
+                                </td>
+                              </tr>
+
+                            </tbody>
+                          </table>
+
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+
+                </div>
+
+                <!--[if mso | IE]></td></tr></table><![endif]-->
+              </div>
+
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+
+
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+    <div style="margin:0px auto;max-width:960px;">
+
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="width:960px;" ><![endif]-->
+
+              <div class="mj-column-per-100 mj-outlook-group-fix"
+                style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
+                <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:top;width:576px;" ><![endif]-->
+
+                <div class="mj-column-per-60 mj-outlook-group-fix"
+                  style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:60%;">
+
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                    <tbody>
+                      <tr>
+                        <td style="vertical-align:top;padding:0px;">
+
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                            <tbody>
+
+                              <tr>
+                                <td align="left" class="font-weight-medium text-h7"
+                                  style="font-size: 0px; padding: 0px; padding-top: 15px; word-break: break-word; font-weight: 500;">
+
+                                  <div
+                                    style="font-family: Roboto, Arial, sans; font-size: 13px; line-height: 150%; text-align: left; text-transform: uppercase; color: #000000; font-weight: 500;">
+                                    Bill To</div>
+
+                                </td>
+                              </tr>
+
+                              <tr>
+                                <td align="left" class="mj-table-customer mj-table-fixed align-baseline"
+                                  style="font-size:0px;padding:0px;word-break:break-word;">
+
+                                  <table cellpadding="0" cellspacing="0" width="100%" border="0"
+                                    style="color: #000000; font-family: Roboto, Arial, sans; font-size: 13px; line-height: 22px; border: none; table-layout: fixed; width: auto;">
+                                    <tr>
+                                      <td class="text-no-wrap"
+                                        style="white-space: nowrap; padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">
+                                        <div style="white-space: nowrap; vertical-align: baseline;">Customer</div>
+                                      </td>
+                                      <td
+                                        style="padding: 2px 24px 2px 0px; vertical-align: baseline; padding-right: 8px;"
+                                        valign="baseline">:</td>
+                                      <td style="padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">{{ data.owner_data.name }}</td>
+                                    </tr>
+                                    <tr>
+                                      <td class="text-no-wrap"
+                                        style="white-space: nowrap; padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">
+                                        <div style="white-space: nowrap; vertical-align: baseline;">Email</div>
+                                      </td>
+                                      <td
+                                        style="padding: 2px 24px 2px 0px; vertical-align: baseline; padding-right: 8px;"
+                                        valign="baseline">:</td>
+                                      <td style="padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">{{ data.owner_data.email if data.owner_data.email else '-' }}</td>
+                                    </tr>
+                                    <tr>
+                                      <td class="text-no-wrap"
+                                        style="white-space: nowrap; padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">
+                                        <div style="white-space: nowrap; vertical-align: baseline;">Phone</div>
+                                      </td>
+                                      <td
+                                        style="padding: 2px 24px 2px 0px; vertical-align: baseline; padding-right: 8px;"
+                                        valign="baseline">:</td>
+                                      <td style="padding: 2px 24px 2px 0px; vertical-align: baseline;"
+                                        valign="baseline">{{ data.owner_data.phone if data.owner_data.phone else '-' }}</td>
+                                    </tr>
+                                  </table>
+
+                                </td>
+                              </tr>
+
+                            </tbody>
+                          </table>
+
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+
+                </div>
+
+                <!--[if mso | IE]></td><td style="vertical-align:top;width:384px;" ><![endif]-->
+
+                <div class="mj-column-per-40 mj-outlook-group-fix"
+                  style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:40%;">
+
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                    <tbody>
+                      <tr>
+                        <td style="vertical-align:top;padding:0px;">
+
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                            <tbody>
+
+                              <tr>
+                                <td align="left" class="font-weight-medium text-h7"
+                                  style="font-size: 0px; padding: 0px; padding-top: 15px; word-break: break-word; font-weight: 500;">
+
+                                  <div
+                                    style="font-family: Roboto, Arial, sans; font-size: 13px; line-height: 150%; text-align: left; text-transform: uppercase; color: #000000; font-weight: 500;">
+                                    Travellers</div>
+
+                                </td>
+                              </tr>
+
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:4px 0;word-break:break-word;">
+
+                                  <div
+                                    style="font-family:Roboto, Arial, sans;font-size:13px;line-height:150%;text-align:left;color:#000000;">
+                                    {{ data.guest_order_data.guest_data[0].full_name }}</div>
+
+                                </td>
+                              </tr>
+
+                            </tbody>
+                          </table>
+
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+
+                </div>
+
+                <!--[if mso | IE]></td></tr></table><![endif]-->
+              </div>
+
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+
+
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+    <div style="margin:0px auto;max-width:960px;">
+
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px;padding-top:25px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:960px;" ><![endif]-->
+
+              <div class="mj-column-per-100 mj-outlook-group-fix"
+                style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                  <tbody>
+                    <tr>
+                      <td style="vertical-align:top;padding:0px;">
+
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                          <tbody>
+
+                            <tr>
+                              <td align="left" class="font-weight-medium text-h7"
+                                style="font-size: 0px; padding: 0px; word-break: break-word; font-weight: 500;">
+
+                                <div
+                                  style="font-family: Roboto, Arial, sans; font-size: 13px; line-height: 150%; text-align: left; text-transform: uppercase; color: #000000; font-weight: 500;">
+                                  Order Details</div>
+
+                              </td>
+                            </tr>
+
+                            <tr>
+                              <td align="left" class="mj-table-order"
+                                style="border-top: hsl(192, 0%, 75%) dotted 2px; border-left: hsl(192, 0%, 50%) solid 4px; border-right: hsl(192, 0%, 90%) solid 3px; font-size: 0px; padding: 0px; word-break: break-word;">
+
+                                <table cellpadding="0" cellspacing="0" width="100%" border="0"
+                                  style="color:#000000;font-family:Roboto, Arial, sans;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                  <tr>
+                                    <th class="left"
+                                      style="text-align: left; vertical-align: middle; padding: 4px 8px; font-weight: 700; border-bottom: hsl(192, 0%, 75%) solid 2px; width: 60%;"
+                                      width="60%" valign="middle" align="left">
+                                      Accomodation
+                                    </th>
+                                    <th class="right"
+                                      style="text-align: right; vertical-align: middle; padding: 4px 8px; font-weight: 700; border-bottom: hsl(192, 0%, 75%) solid 2px;"
+                                      valign="middle" align="right">
+                                      Qty
+                                    </th>
+                                    <th class="right"
+                                      style="text-align: right; vertical-align: middle; padding: 4px 8px; font-weight: 700; border-bottom: hsl(192, 0%, 75%) solid 2px; width: 20%;"
+                                      width="20%" valign="middle" align="right">
+                                      Subtotal
+                                    </th>
+                                  </tr>
+                                  <tr>
+                                    <td style="vertical-align: middle; padding: 4px 8px;" valign="middle">
+                                      <div class>
+                                        {{ data.product_data.name_1 }}
+                                      </div>
+                                      <div class>
+                                        {{ udf_pretty_date(data.dates_data.start_date, data.dates_data.end_date, true) }}
+                                        <b style="margin: 0.25em;">&middot;</b>
+                                        {{ udf_night_duration(data.dates_data.start_date, data.dates_data.end_date) }} nights
+                                      </div>
+                                      <div>
+                                        {{ data.product_data.name_2 }} x {{ data.quantity }}
+                                      </div>
+                                    </td>
+                                    <td class="right text-font-monospace text-no-wrap"
+                                      style="text-align: right; font-family: 'Roboto Mono', Arial, Sans; white-space: nowrap; vertical-align: middle; padding: 4px 8px;"
+                                      valign="middle" align="right">
+                                      {{ udf_night_duration(data.dates_data.start_date, data.dates_data.end_date) * data.quantity }} room
+                                      nights
+                                    </td>
+                                    <td class="right text-font-monospace"
+                                      style="text-align: right; font-family: 'Roboto Mono', Arial, Sans; vertical-align: middle; padding: 4px 8px;"
+                                      valign="middle" align="right">
+                                      {{ udf_format_currency(data.draft_price, 'skip') }}
+                                    </td>
+                                  </tr>
+                                </table>
+
+                              </td>
+                            </tr>
+
+                            <tr>
+                              <td align="left" class="mj-table-price"
+                                style="border-top: hsl(192, 0%, 75%) solid 1px; border-left: transparent solid 4px; border-right: hsl(192, 0%, 90%) solid 3px; font-size: 0px; padding: 0px; word-break: break-word;">
+
+                                <table cellpadding="0" cellspacing="0" width="100%" border="0"
+                                  style="color:#000000;font-family:Roboto, Arial, sans;font-size:13px;line-height:22px;table-layout:fixed;width:100%;border:none;">
+                                  {% if data.omitTaxServiceFee != True %}
+                                  <tr>
+                                    <td
+                                      style="vertical-align: top; padding: 4px 8px; width: 50%; border-bottom: hsl(192, 0%, 90%) solid 1px; border: none;"
+                                      width="50%" valign="top"></td>
+                                    <td class="left"
+                                      style="text-align: left; vertical-align: top; padding: 4px 8px; width: 30%; border-bottom: hsl(192, 0%, 90%) solid 1px; border-left: hsl(192, 0%, 75%) solid 1px;"
+                                      width="30%" valign="top" align="left">
+                                      Tax (VAT) & service fee
+                                    </td>
+                                    <td class="right text-font-monospace"
+                                      style="text-align: right; font-family: 'Roboto Mono', Arial, Sans; vertical-align: top; padding: 4px 8px; width: 20%; border-bottom: hsl(192, 0%, 90%) solid 1px;"
+                                      width="20%" valign="top" align="right">
+                                      Included
+                                    </td>
+                                  </tr>
+                                  {% endif %}
+
+                                  {% for item in data.price_breakdown %}
+                                  {% if item.type_code != 'BO' %}
+                                  <tr>
+                                    <td
+                                      style="vertical-align: top; padding: 4px 8px; width: 50%; border-bottom: hsl(192, 0%, 90%) solid 1px; border: none;"
+                                      width="50%" valign="top"></td>
+                                    <td class="left"
+                                      style="text-align: left; vertical-align: top; padding: 4px 8px; width: 30%; border-bottom: hsl(192, 0%, 90%) solid 1px; border-left: hsl(192, 0%, 75%) solid 1px;"
+                                      width="30%" valign="top" align="left">
+                                      <div>
+                                        {{ item.type_description }} {{ ('(' + item.note + ')') if item.note else '' }}
+                                      </div>
+                                    </td>
+                                    <td class="right text-font-monospace"
+                                      style="text-align: right; font-family: 'Roboto Mono', Arial, Sans; vertical-align: top; padding: 4px 8px; width: 20%; border-bottom: hsl(192, 0%, 90%) solid 1px;"
+                                      width="20%" valign="top" align="right">
+                                      {{ udf_format_currency(item.amount, 'skip') }}
+                                    </td>
+                                  </tr>
+                                  {% endif %}
+                                  {% endfor %}
+
+                                  <tr>
+                                    <td
+                                      style="vertical-align: top; padding: 4px 8px; width: 50%; border-top: hsl(192, 0%, 75%) double 1px; border-bottom: hsl(192, 0%, 90%) solid 3px; border: none;"
+                                      width="50%" valign="top"></td>
+                                    <td class="left font-weight-medium"
+                                      style="text-align: left; vertical-align: top; padding: 4px 8px; width: 30%; border-top: hsl(192, 0%, 75%) double 1px; border-bottom: hsl(192, 0%, 90%) solid 3px; border-left: hsl(192, 0%, 75%) solid 1px; font-weight: 500;"
+                                      width="30%" valign="top" align="left">
+                                      Total
+                                    </td>
+                                    <td class="right font-weight-medium text-font-monospace"
+                                      style="text-align: right; font-family: 'Roboto Mono', Arial, Sans; vertical-align: top; padding: 4px 8px; width: 20%; border-top: hsl(192, 0%, 75%) double 1px; border-bottom: hsl(192, 0%, 90%) solid 3px; font-weight: 500;"
+                                      width="20%" valign="top" align="right">
+                                      {{ udf_format_currency(data.final_price) }}
+                                    </td>
+                                  </tr>
+                                </table>
+
+                              </td>
+                            </tr>
+
+                          </tbody>
+                        </table>
+
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+
+              </div>
+
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+
+
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+
+    {% if (app_config.app.tenant_name == 'wisatajawa') and (data.paymentMethod == 'BILL') %}
+    <div style="margin-top: 32px;"></div>
+    <div class="roboto">
+      <div style="line-height: 1.5; font-size: 14px; font-family: Roboto, system-ui;">
+        Rekening BCA<br>
+        AN. PT WISATA JAWA INDAH<br>
+        AC. 1035599888
+      </div>
+    </div>
+    {% endif %}
+    {% if (app_config.app.tenant_name == 'wisatajawa') and (footer.show_download_app) %}
+    <div style="padding-top: 100px;">
+    </div>
+    {% include 'footer.html' %}
+    {% endif %}
+  </div>
+
+</body>
+
+</html>

--- a/templates/wisata-bill.html
+++ b/templates/wisata-bill.html
@@ -1,0 +1,909 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+  xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title>
+
+  </title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet"
+    type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap);
+  </style>
+  <!--<![endif]-->
+
+
+
+  <style type="text/css">
+
+
+  </style>
+  <style type="text/css">
+    html {
+      scrollbar-width: none;
+      color: #121212;
+    }
+
+    html * {
+      font-size: 13px;
+      font-family: -apple-system, BlinkMacSystemFont, Roboto, system-ui, sans-serif;
+    }
+
+    ::-webkit-scrollbar {
+      display: none !important;
+    }
+
+    .body {
+      padding-top: 3rem;
+      padding-bottom: 3rem;
+    }
+
+    .anchor-href,
+    .anchor-href:active,
+    .anchor-href:visited {
+      color: inherit;
+      font-size: inherit;
+    }
+
+    .anchor-href:hover {
+      text-decoration: underline;
+    }
+
+    .page-title-and-logo {
+      margin-top: 24px;
+      margin-bottom: 12px;
+      position: relative;
+      display: flex;
+      flex-flow: row nowrap;
+      align-items: center;
+    }
+
+    .header-logo {
+      max-width: 160px;
+      max-height: 72px;
+      object-fit: contain;
+      float: right;
+    }
+
+    table th,
+    table td {
+      vertical-align: top !important;
+    }
+
+    table.table-billing-header {
+      line-height: 1.5;
+      width: auto !important;
+    }
+
+    table.table-billing-txn {
+      line-height: 1.5;
+      width: 100% !important;
+    }
+
+    table.table-invoice-header {
+      line-height: 1.25;
+      width: auto !important;
+    }
+
+    table.table-invoice-order {
+      line-height: 1.5;
+      display: block !important;
+      width: 960px;
+    }
+
+    table.table-billing-recap {
+      line-height: 1.5;
+    }
+
+    table.table-billing-recap thead tr th,
+    table.table-billing-recap tbody tr td,
+    table.table-billing-recap tfoot tr td {
+      text-overflow: ellipsis;
+      vertical-align: top;
+      padding: 0.25rem;
+    }
+
+    table.table-billing-header thead tr th,
+    table.table-billing-header tbody tr td {
+      text-overflow: ellipsis;
+      vertical-align: top;
+      padding: 0.25rem 1.5rem 0.25rem 0;
+    }
+
+    table.table-billing-txn tbody tr.txn-credit {
+      background-color: #f4f4f4;
+    }
+
+    table.table-billing-txn thead tr,
+    table.table-billing-txn tbody tr {
+      page-break-inside: avoid;
+    }
+
+    table.table-billing-txn thead tr th,
+    table.table-billing-txn tbody tr td {
+      font-size: 13px;
+      text-overflow: ellipsis;
+      vertical-align: top;
+      padding: 0.25rem 0.5rem 0.25rem 0.5rem;
+    }
+
+    table.table-billing-txn thead tr th {
+      border-top: 2px solid #212121;
+      border-bottom: 2px solid #212121;
+    }
+
+    table.table-billing-txn tbody tr td {
+      border-bottom: 2px solid #EAEAEA;
+    }
+
+    table.table-billing-txn tbody tr:last-child td:first-child {
+      border-bottom: none !important;
+    }
+
+    table.table-billing-txn tbody tr:last-child td:nth-child(n+2) {
+      border-bottom: 2px solid #212121;
+    }
+
+    table.table-invoice-header thead tr th,
+    table.table-invoice-header tbody tr td {
+      padding: 0.25rem 1.5rem 0.25rem 0;
+    }
+
+    table.table-invoice-order thead tr th,
+    table.table-invoice-order tbody tr td {
+      padding: 0.5rem;
+    }
+
+    table.table-invoice-order thead tr th {
+      border-top: 2px solid #212121;
+      border-bottom: 2px solid #212121;
+    }
+
+    table.table-invoice-order tbody tr:first-child td {
+      border-bottom: 3px solid #EAEAEA;
+    }
+
+    table.table-invoice-order tbody tr:nth-child(n+2) td:nth-child(n+3) {
+      border-bottom: 1px solid #EAEAEA;
+    }
+
+    table.table-invoice-order tbody tr:last-child td:nth-child(n+3) {
+      border-bottom: 2px solid #424242;
+    }
+
+    table td.border-b-0 {
+      border-bottom: none !important;
+    }
+
+    .text-no-wrap {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .text-red {
+      color: #f44336;
+    }
+
+    .text-grey {
+      color: #b2b2b2;
+    }
+
+    .text-right {
+      text-align: right;
+    }
+
+    .text--secondary {
+      color: #808080;
+    }
+
+    .text-h5 {
+      font-size: 1.375rem;
+    }
+
+    .text-h6 {
+      font-size: 1.25rem;
+    }
+
+    .text-h7 {
+      font-size: 1.125rem;
+    }
+
+    .font-weight-medium {
+      font-weight: 500 !important;
+    }
+
+    .font-weight-bold {
+      font-weight: 700 !important;
+    }
+
+    .new-page {
+      display: block !important;
+      page-break-before: always;
+    }
+
+    .price-breakdown-grid {
+      display: grid;
+      grid-template-columns: minmax(8ch, auto) minmax(8ch, auto) 1fr;
+      gap: 0 0.5rem;
+    }
+
+    .price-breakdown-grid>* {
+      line-height: 1.375 !important;
+      font-size: 12px !important;
+    }
+  </style>
+
+</head>
+
+<body style="word-spacing:normal;">
+
+
+  <div style>
+
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+      <tbody>
+        <tr>
+          <td>
+
+
+            <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:960px;" width="960" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+            <div style="margin:0px auto;max-width:960px;">
+
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                <tbody>
+                  <tr>
+                    <td style="direction:ltr;font-size:0px;padding:0px;text-align:left;">
+                      <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><![endif]-->
+
+                      <div>
+                        <div class="page-title-and-logo text-h6 font-weight-bold">
+                          <div class="text-h5 font-weight-bold">
+                            Billing Statement
+                          </div>
+                          <img src="{{ header.logo_src }}" alt class="header-logo"
+                            style="position: absolute; right: 0;">
+                        </div>
+
+                        <div style="margin: 24px 0;"></div>
+                        <div
+                          style="display: flex; flex-flow: row nowrap; justify-content: space-between; align-items: flex-start;">
+                          <table class="table-billing-header" style="align-self: flex-start;">
+                            <tbody>
+                              <tr>
+                                <td>
+                                  Bill To
+                                </td>
+                                <td style="padding-right: 0.5rem !important;">
+                                  :
+                                </td>
+                                <td>
+                                  {{ data.onBehalfAccountData.username }}
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  Billing Period
+                                </td>
+                                <td style="padding-right: 0.5rem !important;">
+                                  :
+                                </td>
+                                <td>
+                                  {{ udf_pretty_date(data.billingPeriodStart, data.billingPeriodEnd, true) }}
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  Print Date
+                                </td>
+                                <td style="padding-right: 0.5rem !important;">
+                                  :
+                                </td>
+                                <td>
+                                  {{ udf_pretty_date(data.billingPrintDate) }}
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  Due Date
+                                </td>
+                                <td style="padding-right: 0.5rem !important;">
+                                  :
+                                </td>
+                                <td>
+                                  {{ udf_pretty_date(data.billingDueDate, null, true) }}
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+
+                          <table class="table-billing-recap" style="align-self: flex-start;">
+                            <tbody>
+                              <tr>
+                                <td class="text-no-wrap">
+                                  Total Payment
+                                </td>
+                                <td style="padding-right: 0.5rem !important;">
+                                  :
+                                </td>
+                                <td class="monospace text-no-wrap text-right font-weight-bold"
+                                  style="font-family: Courier, monospace;">
+                                  {{ udf_format_currency(data.totalPayment|abs) }}
+                                </td>
+                              </tr>
+                              <tr>
+                                <td class="text-no-wrap">
+                                  Total Purchase
+                                </td>
+                                <td style="padding-right: 0.5rem !important;">
+                                  :
+                                </td>
+                                <td class="monospace text-no-wrap text-right font-weight-bold"
+                                  style="font-family: Courier, monospace;">
+                                  {{ udf_format_currency(data.totalPurchase) }}
+                                </td>
+                                <td style="width: 24px;"></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+
+                        <div style="margin-top: 12px; line-height: 1.5;">
+                          Rekening BCA<br>
+                          AN. PT WISATA JAWA INDAH<br>
+                          AC. 1035599888
+                        </div>
+                        <div style="margin-top: 36px;"></div>
+
+                        <div class="text-h7 font-weight-bold" style="margin-bottom: 8px;">
+                          Payment Summary
+                        </div>
+                        <p style="margin: 0; margin-bottom: 8px;">
+                          {% if data.paymentList|length > 0%}
+                          Here's a summary of your payment on {{ udf_pretty_date(data.billingPeriodStart,
+                          data.billingPeriodEnd, true) }}
+                          {% else %}
+                          There's no payment on {{ udf_pretty_date(data.billingPeriodStart, data.billingPeriodEnd, true)
+                          }}
+                          {% endif %}
+                        </p>
+                        <table class="table-billing-txn">
+                          <thead>
+                            <tr>
+                              <th class="text-no-wrap" style="width: 1%;">
+                                Date
+                              </th>
+                              <th class="text-no-wrap">
+                                Payment
+                              </th>
+                              <th></th>
+                              <th class="text-right text-no-wrap" style="width: 1%; min-width: 120px;">
+                                Amount (Rp)
+                              </th>
+                              <th style="width: 24px;"></th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {% if data.paymentList|length == 0 %}
+                            <tr>
+                              <td>-</td>
+                              <td>-</td>
+                              <td>-</td>
+                              <td>-</td>
+                              <td>-</td>
+                            </tr>
+                            {% endif %}
+
+                            {% for item in data.paymentList %}
+                            <tr style="background-color: #f4f4f4;">
+                              <td class="text-no-wrap">
+                                {{ udf_pretty_date(item.txn_date, null, true) }}
+                              </td>
+                              <td colspan="2" style="max-width: 420px;">
+                                {{ item.txn_data.txn_subtitle }}
+                              </td>
+                              <td class="monospace text-right font-weight-bold"
+                                style="font-family: Courier, monospace;">
+                                {{ udf_format_currency(item.amount|abs, 'skip') }}
+                              </td>
+                              <td class="monospace font-weight-bold" style="font-family: Courier, monospace;">
+                                CR
+                              </td>
+                            </tr>
+                            {% endfor %}
+                            <tr>
+                              <td class="border-b-0"></td>
+                              <td class="border-b-0"></td>
+                              <td class="text-no-wrap font-weight-bold">
+                                Total
+                              </td>
+                              <td class="monospace text-right font-weight-bold"
+                                style="font-family: Courier, monospace;">
+                                {{ udf_format_currency(data.totalPayment|abs) }}
+                              </td>
+                              <td></td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <br>
+                        <br>
+                        <div class="text-h7 font-weight-bold" style="margin-bottom: 8px;">
+                          Purchase Summary
+                        </div>
+                        <p style="margin: 0; margin-bottom: 8px;">
+                          {% if data.purchaseList|length > 0 %}
+                          Here's a summary of your purchase on {{ udf_pretty_date(data.billingPeriodStart,
+                          data.billingPeriodEnd, true) }}
+                          {% else %}
+                          There's no purchase on {{ udf_pretty_date(data.billingPeriodStart, data.billingPeriodEnd,
+                          true) }}
+                          {% endif %}
+                        </p>
+                        <table class="table-billing-txn">
+                          <thead>
+                            <tr>
+                              <th class="text-no-wrap">
+                                <div style="min-width: 80px;">
+                                  Date
+                                </div>
+                              </th>
+                              <th class="text-no-wrap" style="width: 1%;">
+                                Order ID
+                              </th>
+                              <th class="text-no-wrap" style="width: 99%;">
+                                Order Summary
+                              </th>
+                              <th class="text-no-wrap" style="width: 1%;">
+                                Details
+                              </th>
+                              <th class="text-right text-no-wrap" style="width: 1%; min-width: 120px;">
+                                Amount (Rp)
+                              </th>
+                              <th>
+                                <div style="width: 24px;"></div>
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {% if data.purchaseList|length == 0 %}
+                            <tr>
+                              <td>-</td>
+                              <td>-</td>
+                              <td>-</td>
+                              <td>-</td>
+                              <td>-</td>
+                              <td>-</td>
+                            </tr>
+                            {% endif %}
+
+                            {% for item in data.purchaseList %}
+                            {% if item.amount < 0 %} <tr class="txn-credit">
+                              {% else %}
+                  </tr>
+                  <tr>
+                    {% endif %}
+                    <td class="text-no-wrap">
+                      <div style="min-width: 80px; font: inherit;">
+                        {{ udf_pretty_date(item.latest_txn_date, null, true) }}
+                      </div>
+                    </td>
+                    <td class="text-no-wrap">
+                      <a href="#invoice-{{ item.booking_data.booking_id }}" class="anchor-href font-weight-bold">
+                        #{{ item.booking_data.booking_id }}
+                      </a>
+                    </td>
+                    <td>
+                      {{ item.booking_data.product_data.name_1 }},
+                      {% if item.booking_data.dates_data.start_date %}
+                      {{ udf_pretty_date(item.booking_data.dates_data.start_date, null, true) }},
+                      {% else %}
+                      {{ '' }}
+                      {% endif %}
+                      {{ item.booking_data.guest_order_data.guest_data[0].full_name }}
+                    </td>
+                    <td>
+                      <div class="price-breakdown-grid">
+                        {% for pb in item.booking_data.price_breakdown_agg %}
+                        {% if bill_is_past_txn(pb.txn_dt, data.billingPeriodStart) %}
+                        <div class="monospace text-grey" style="font-family: Courier, monospace;">
+                          {% else %}
+                          <div class="monospace" style="font-family: Courier, monospace;">
+                            {% endif %}
+                            {{ pb.type_description }}
+                          </div>
+
+                          {% if item.booking_data.is_purchase_only%}
+                          <div>
+                          </div>
+                          {% elif bill_is_past_txn(pb.txn_dt, data.billingPeriodStart) %}
+                          <div class="monospace text-grey text-no-wrap"
+                            style="justify-self: flex-end; font-family: Courier, monospace;">
+                            {{ udf_pretty_date(pb.txn_dt, null, true) }}
+                          </div>
+                          {% else %}
+                          <div class="monospace text-no-wrap"
+                            style="justify-self: flex-end; font-family: Courier, monospace;">
+                            {{ udf_pretty_date(pb.txn_dt, null, true) }}
+                          </div>
+                          {% endif %}
+
+                          {% if item.booking_data.is_purchase_only%}
+                          <div></div>
+                          {% elif bill_is_past_txn(pb.txn_dt, data.billingPeriodStart) %}
+                          <div class="text-grey text-no-wrap monospace text-right"
+                            style="font-family: Courier, monospace;">
+                            {{ udf_format_currency(pb.amount, 'skip') }}
+                          </div>
+                          {% else %}
+                          <div class="text-no-wrap monospace text-right" style="font-family: Courier, monospace;">
+                            {{ udf_format_currency(pb.amount, 'skip') }}
+                          </div>
+                          {% endif %}
+                          {% endfor %}
+                        </div>
+                      </div>
+                    </td>
+                    <td class="monospace text-right font-weight-bold" style="font-family: Courier, monospace;">
+                      {{ udf_format_currency(item.booking_data.price_breakdown_agg_total|abs, 'skip') }}
+                    </td>
+                    <td class="monospace font-weight-bold" style="font-family: Courier, monospace;">
+                      {% if item.booking_data.price_breakdown_agg_total < 0 %} CR {% endif %} </td>
+                  </tr>
+                  {% endfor %}
+                  <tr>
+                    <td colspan="3" class="border-b-0"></td>
+                    <td class="text-no-wrap font-weight-bold">
+                      Total
+                    </td>
+                    <td colspan="1" class="monospace text-right font-weight-bold"
+                      style="font-family: Courier, monospace;">
+                      {{ udf_format_currency(data.totalPurchase) }}
+                    </td>
+                    <td></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            {% for item in data.purchaseList %}
+            {% if item.booking_data %}
+            <div class="new-page">
+              <div class="page-title-and-logo">
+                <div id="invoice-{{ item.booking_data.booking_id }}" class="text-h5 font-weight-bold">
+                  Invoice
+                </div>
+                <img src="{{ header.logo_src }}" alt class="header-logo" style="position: absolute; right: 0;">
+              </div>
+              <table class="table-invoice-header">
+                <tbody>
+                  <tr>
+                    <td>
+                      Number
+                    </td>
+                    <td style="padding-right: 0.5rem !important;">
+                      :
+                    </td>
+                    <td>
+                      {{ item.booking_data.booking_id }}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="text-no-wrap">
+                      Booking Date
+                    </td>
+                    <td style="padding-right: 0.5rem !important;">
+                      :
+                    </td>
+                    <td>
+                      {{ udf_pretty_date(item.booking_data.created_date, null, true) }}
+                    </td>
+                  </tr>
+                  <tr>
+                    {% if udf_pretty_date(item.booking_data.created_date) != udf_pretty_date(item.latest_txn_date) %}
+                    <td>
+                      Last Updated Date
+                    </td>
+                    <td style="padding-right: 0.5rem !important;">
+                      :
+                    </td>
+                    <td>
+                      {{ udf_pretty_date(item.latest_txn_date, null, true) }}
+                    </td>
+                    {% endif %}
+                  </tr>
+                  <tr>
+                    <td colspan="3" class="font-weight-bold">
+                      <div style="margin-top: 16px;">
+                        BILL TO
+                      </div>
+                    </td>
+                    <td>
+                      <div style="min-width: 48px;"></div>
+                    </td>
+                    <td colspan="3" class="font-weight-bold">
+                      <div style="margin-top: 16px;">
+                        TRAVELERS
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Customer
+                    </td>
+                    <td style="padding-right: 0.5rem !important;">
+                      :
+                    </td>
+                    <td>
+                      {{ item.booking_data.owner_data.name }}
+                    </td>
+                    <td></td>
+                    <td>
+                      Name
+                    </td>
+                    <td style="padding-right: 0.5rem !important;">
+                      :
+                    </td>
+                    <td rowspan="3">
+                      <div style="max-width: 320px;">
+                        {{ item.booking_data.guest_order_data.guest_data[0].full_name }}
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Email
+                    </td>
+                    <td style="padding-right: 0.5rem !important;">
+                      :
+                    </td>
+                    <td>
+                      {% if item.booking_data.owner_data.email %}
+                      {{ item.booking_data.owner_data.email }}
+                      {% else %}
+                      -
+                      {% endif %}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Phone
+                    </td>
+                    <td style="padding-right: 0.5rem !important;">
+                      :
+                    </td>
+                    <td>
+                      {% if item.booking_data.owner_data.phone %}
+                      {{ item.booking_data.owner_data.phone }}
+                      {% else %}
+                      -
+                      {% endif %}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+
+              <div class="font-weight-bold" style="margin-top: 24px; margin-bottom: 0.75em;">
+                ORDER DETAILS
+              </div>
+              <table class="table-invoice-order" style="width: 100%;">
+                <thead>
+                  <tr>
+                    <th class="font-weight-bold">
+                      Accomodation
+                    </th>
+                    <th class="font-weight-bold text-right">
+                      Quantity
+                    </th>
+                    <th class="font-weight-bold" style="width: 1%; min-width: 240px;">
+                      Details
+                    </th>
+                    <th class="font-weight-bold text-right" style="width: 1%; min-width: 180px;">
+                      Subtotal (Rp)
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <div style="line-height: 1.5;">
+                        {{ item.booking_data.product_data.name_1 }}
+                      </div>
+                      <div style="line-height: 1.5;">
+                        {{ udf_pretty_date(item.booking_data.dates_data.start_date, item.booking_data.dates_data.end_date, true) }}
+                      </div>
+                      <div style="line-height: 1.5;">
+                        <span>
+                          {{ item.booking_data.product_data.name_2 }}
+                        </span>
+                        <span class="font-weight-medium">
+                          {% if item.booking_data.product_division == 'stay' %}
+                          x {{ item.booking_data.quantity }}
+                          {% endif %}
+                        </span>
+                      </div>
+                    </td>
+                    {% if item.booking_data.product_division == 'stay' %}
+                    <td class="text-right">
+                      {{ udf_night_duration(item.booking_data.dates_data.start_date, item.booking_data.dates_data.end_date) * item.booking_data.quantity }} room nights
+                    </td>
+                    {% elif item.booking_data.product_division == 'document' %}
+                    <td class="text-right">
+                      {{ item.booking_data.quantity }}
+                    </td>
+                    {% endif %}
+                    <td>
+                      <div class="text--secondary">
+                        {% if bill_is_past_booking(item.booking_data.price_breakdown, data.billingPeriodStart) %}
+                        Purchased on {{ udf_pretty_date(item.booking_data.created_date, null, true) }}
+                        {% else %}
+                        -
+                        {% endif %}
+                      </div>
+                    </td>
+                    <td
+                      class="monospace text-right font-weight-bold {{ 'text--secondary' if bill_is_past_booking(item.booking_data.price_breakdown, data.billingPeriodStart) else '' }}"
+                      style="font-family: Courier, monospace;">
+                      {{ udf_format_currency(item.booking_data.draft_price, 'skip') }}
+                    </td>
+                  </tr>
+                  {% if item.booking_data.product_division == 'stay' %}
+                  <tr>
+                    <td></td>
+                    <td></td>
+                    <td
+                      class="text-no-wrap {{ 'text--secondary' if bill_is_past_booking(item.booking_data.price_breakdown, data.billingPeriodStart) else '' }}">
+                      Tax (VAT) & service fee
+                    </td>
+                    <td
+                      class="text-right {{ 'text--secondary' if bill_is_past_booking(item.booking_data.price_breakdown, data.billingPeriodStart) else '' }}">
+                      Included
+                    </td>
+                  </tr>
+                  {% endif %}
+                  {% for pb in item.booking_data.price_breakdown %}
+                  {% if pb.type_code != 'BO' and bill_is_future_txn(pb.txn_dt, data.billingPeriodEnd) == False %}
+                  <tr>
+                    <td></td>
+                    <td></td>
+                    {% if pb.type == 'CBX' and pb.amount > 0 %}
+                    <td class="text-red">
+                      {% elif pb.type == 'CBX' and pb.amount <= 0 %} </td>
+                    <td
+                      class="{{ 'text--secondary' if bill_is_past_booking(item.booking_data.price_breakdown, data.billingPeriodStart) else '' }}">
+                      {% elif pb.type == 'CCL' %}
+                    </td>
+                    <td class="text-red">
+                      {% elif pb.type == 'RFND' %}
+                    </td>
+                    <td class="text-red">
+                      {% else %}
+                    </td>
+                    <td>
+                      {% endif %}
+                      <div>
+                        {{ pb.type_description }} {{ ('(' + pb.note + ')') if pb.note else '' }}
+                        {% if pb.type in ['CCL', 'RFND', 'ADJ'] %}
+                        <span style="display: inline-block;">
+                          (on {{ udf_pretty_date(pb.txn_dt, null, true) }})
+                        </span>
+                        {% endif %}
+                      </div>
+                    </td>
+
+                    {% if pb.type == 'CBX' and pb.amount > 0 %}
+                    <td class="monospace text-right text-red font-weight-bold" style="font-family: Courier, monospace;">
+                      {% elif pb.type == 'CBX' and pb.amount <= 0 %} </td>
+                    <td
+                      class="monospace text-right font-weight-bold {{ 'text--secondary' if bill_is_past_booking(item.booking_data.price_breakdown, data.billingPeriodStart) else '' }}"
+                      style="font-family: Courier, monospace;">
+                      {% elif pb.type == 'CCL' %}
+                    </td>
+                    <td class="monospace text-right text-red font-weight-bold" style="font-family: Courier, monospace;">
+                      {% elif pb.type == 'RFND' %}
+                    </td>
+                    <td class="monospace text-right text-red font-weight-bold" style="font-family: Courier, monospace;">
+                      {% else %}
+                    </td>
+                    <td class="monospace text-right font-weight-bold" style="font-family: Courier, monospace;">
+                      {% endif %}
+                      {{ udf_format_currency(pb.amount, 'skip') }}
+                    </td>
+                  </tr>
+                  {% endif %}
+                  {% endfor %}
+                  <tr>
+                    <td></td>
+                    <td></td>
+                    <td class="font-weight-bold">
+                      Total
+                    </td>
+                    <td class="monospace text-right font-weight-bold" style="font-family: Courier, monospace;">
+                      {{ udf_format_currency(bill_sum_of_price_breakdown(item.booking_data.price_breakdown, data.billingPeriodStart, data.billingPeriodEnd)) }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+            {% endfor %}
+
+            <!--[if mso | IE]></table><![endif]-->
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+
+  <!--[if mso | IE]></td></tr></table><![endif]-->
+
+
+  </td>
+  </tr>
+  </tbody>
+  </table>
+
+  </div>
+
+</body>
+
+</html>

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,11 @@
 from datetime import datetime
 import re
 
+def udf_txn_booking_id(txn_data):
+    if (txn_data['txn_subtitle'] and txn_data['txn_subtitle'].startswith('Booking #')):
+        return txn_data['txn_subtitle'].replace('Booking #', '')
+    return None   
+
 """
 date value variants:
 1. YYYY-MM-DD, e.g 2023-01-01

--- a/utils.py
+++ b/utils.py
@@ -238,14 +238,11 @@ def flight_get_facilities_per_passenger(provider_booking_list, passenger_number)
                 if not baggage_fare_details:
                     continue
 
-                result.append(f"<div class='text-body-1 font-weight-medium'>{segment['origin']} - {segment['destination']}</div>")
+                result.append(f"<div class='text-body-1 font-weight-bold'>{segment['origin']} - {segment['destination']}</div>")
                 result.append(f"<div class='text-body-1'>{baggage_fare_details['detail_name']}</div>")
-        
-                result.append(f"{segment['origin']} - {segment['destination']}")
-                result.append(baggage_fare_details['detail_name'])
 
                 if extra_baggage_fee_data:
-                    result.append(f"<div class='text-body-1'>Extra baggage: <span class='font-weight-bold'>{extra_baggage_fee_data['fee_value']}</span></div>")
+                    result.append(f"<div class='text-body-1'>Extra baggage: <span class='font-weight-bold'>{extra_baggage_fee_data['fee_value']} KG</span></div>")
                 
                 if chargeable_seat_fee_data:
                     result.append(f"<div class='text-body-1'>Seat: <span class='font-weight-bold'>{chargeable_seat_fee_data['fee_value']}</span></div>")

--- a/utils.py
+++ b/utils.py
@@ -4,16 +4,32 @@ import re
 """
 date value variants:
 1. YYYY-MM-DD, e.g 2023-01-01
-2. ISO timestamp. e.g 2023-07-04T03:06:28.125594+00:00
+2. Rodex timestamp, e.g 2023-01-01 23:59:59
+3. ISO timestamp. e.g 2023-07-04T03:06:28.125594+00:00
 """
 def udf_date_parse(date):
+    result = None
     try:
-        return datetime.strptime(date, '%Y-%m-%d')
-    except Exception as e:
-        if ('unconverted data remains' in str(e)):
-            return datetime.strptime(date, '%Y-%m-%dT%H:%M:%S.%f%z')
-        else:
-            raise e
+        result = datetime.strptime(date, '%Y-%m-%d')
+    except:
+        # silent error
+        pass
+    try:
+        result = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
+    except:
+        # silent error
+        pass
+    try:
+        result = datetime.strptime(date, '%Y-%m-%dT%H:%M:%S.%f%z')
+    except:
+        # silent error
+        pass
+
+    if (result == None):
+
+        raise ValueError('invalid date parser format')
+
+    return result
 
 
 """
@@ -160,3 +176,101 @@ def bill_sum_of_price_breakdown(price_breakdown_list, billing_period_start, bill
             continue
         total = total + item['amount']
     return total
+
+def get(obj, *args):
+    if obj == None:
+        return None
+    if len(args) == 0:
+        return obj
+    if len(args) == 1:
+        return obj[args[0]]
+    return get(obj[args[0]], *args[1:])
+
+def get_day_from_date(time_str):
+  date_obj = udf_date_parse(time_str)
+  return date_obj.strftime("%a")
+
+def get_time_from_date(time_str, is_include_seconds = False):
+    date_obj = udf_date_parse(time_str)
+    return date_obj.strftime("%H:%M:%S" if is_include_seconds else "%H:%M")
+
+def flight_get_all_segments_by_journey(journey):
+    segments = journey['segments']
+    result = []
+    for segment in segments:
+        legs = segment['legs']
+        for leg in legs:
+            result.append({
+                **leg,
+                'carrier_code': segment['carrier_code'],
+                'carrier_name': segment['carrier_name'],
+                'carrier_number': segment['carrier_number'],
+                'carrier_type_name': segment['carrier_type_name'],
+                'cabin_class': segment['cabin_class'],
+            })
+    return result
+
+def flight_get_facilities_per_passenger(provider_booking_list, passenger_number):
+    result = []
+    for booking in provider_booking_list:
+        for journey in booking['journeys']:
+            ticket = None
+            for t in booking['tickets']:
+                if int(t['passenger_number']) == int(passenger_number):
+                    ticket = t
+                    break
+                
+            for segment in journey['segments']:
+                extra_baggage_fee_data = None
+                chargeable_seat_fee_data = None
+                for fee in ticket['fees']:
+                    if fee['fee_type'] == 'SSR' and fee['fee_category'] == 'baggage' and (fee['journey_code'] == segment['segment_code'] or fee['journey_code'] == journey['journey_code']):
+                        extra_baggage_fee_data = fee
+                    if fee['fee_type'] == 'SEAT' and fee['journey_code'] == segment['segment_code']:
+                        chargeable_seat_fee_data = fee
+
+                baggage_fare_details = None
+                for fare_detail in segment['fare_details']:
+                    if fare_detail['detail_type'] == 'BGA':
+                        baggage_fare_details = fare_detail
+                        break
+
+                if not baggage_fare_details:
+                    continue
+
+                result.append(f"<div class='text-body-1 font-weight-medium'>{segment['origin']} - {segment['destination']}</div>")
+                result.append(f"<div class='text-body-1'>{baggage_fare_details['detail_name']}</div>")
+        
+                result.append(f"{segment['origin']} - {segment['destination']}")
+                result.append(baggage_fare_details['detail_name'])
+
+                if extra_baggage_fee_data:
+                    result.append(f"<div class='text-body-1'>Extra baggage: <span class='font-weight-bold'>{extra_baggage_fee_data['fee_value']}</span></div>")
+                
+                if chargeable_seat_fee_data:
+                    result.append(f"<div class='text-body-1'>Seat: <span class='font-weight-bold'>{chargeable_seat_fee_data['fee_value']}</span></div>")
+    return ''.join(result)
+
+def flight_get_ticket_number(providerBookingList, passengerNumber):
+    ticket = None
+    for booking in providerBookingList:
+        for t in booking['tickets']:
+            if int(t['passenger_number']) == int(passengerNumber):
+                ticket = t
+                break
+    return ticket['ticket_number'] if ticket else ''
+
+def flight_get_total_fees_per_passenger(pnr, passengerList, passengerNumber):
+    totalFees = 0
+    pnrList = pnr.split(',') if pnr else []
+    pnrList = [pnr.strip() for pnr in pnrList]
+    if not pnrList or not isinstance(pnrList, list):
+        return totalFees
+    passenger = next((p for p in passengerList if int(p['passenger_number']) == int(passengerNumber)), None)
+    for pnr in pnrList:
+        sale_service_charges = passenger['sale_service_charges'].get(pnr) if passenger else None
+        if sale_service_charges and isinstance(sale_service_charges, dict):
+            for charge in sale_service_charges.values():
+                if isinstance(charge['amount'], int) or isinstance(charge['amount'], float):
+                    totalFees += charge['amount']
+    return totalFees


### PR DESCRIPTION
### Description
1. Update PDF margins
2. Migrate wisatabill related utils to python
3. Create wisata bill template

### How to Test
1. Open chrome > chrome web inspector > network
2. Open https://project-exterior.com, login as backoffice
3. In dashboard, click `Backoffice` tab then choose `See Offline Bill`
4. In payment page, replace `on_behalf` query with one of these ID:
    | | |
    | --- | --- |
    | rodamas | 44 |
    | libing | 131 |
    | tumbakmas | 2117 |
    | sasainti | 64089 |
5. Download any billing statement
6. Network inspector should show request to `/api/print`
7. Copy value in `context` and paste into `data` in payload template below
    ```json5
    {
      "type": "wisata-bill",
      "format": "pdf",
      "filename": "My document",
      "header": {
        "logo_src": "https://cdn.wisata.app/f/52ee9453-c8c7-452d-9457-7674df571c8f.jpeg",
        "logo_alt": ""
      },
      "footer": {
        "show_download_app": false
      },
     "data": { /* ... */ }, // <-- put here
    }
    ```
8. Make request to `http://localhost:8000/print` with payload above
9. Compare billing statement downloaded from project-exterior and this project

### Test Result
| account | project-exterior | this project | notes |
| --- | --- | --- | --- |
| Rodamas July 2023 | [project-exterior.pdf](https://github.com/amardevsingh98/python-html-to-pdf/files/12330657/Wisata.Bill.Billing.Statement.-.Jul.2023.Wisata.App.22.pdf) | [response.pdf](https://github.com/amardevsingh98/python-html-to-pdf/files/12330658/response.pdf) | |
| Rodamas June 2023 | [project-exterior.pdf](https://github.com/amardevsingh98/python-html-to-pdf/files/12330662/Wisata.Bill.Billing.Statement.-.Jun.2023.Wisata.App.-.2023-08-14T063040.133.pdf) | [response.pdf](https://github.com/amardevsingh98/python-html-to-pdf/files/12330663/response.pdf) | has cancellation (both in diff period and in same period) |


