### PR TITLE
Templates: offline booking custom invoice

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ class PrintType(str, Enum):
     Debug = 'debug'
     StayVoucher = 'stay-voucher'
     WisataBill = 'wisata-bill'
+    OfflineBookingCustomInvoice = 'offline-booking-custom-invoice'
 
 class PrintFormat(str, Enum):
     HTML = "html"

--- a/templates/offline-booking-custom-invoice.html
+++ b/templates/offline-booking-custom-invoice.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link type="text/css" href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+  <style>
+    html {
+      font-size: 14px !important;
+    }
+
+    p {
+      margin: 0 !important;
+    }
+
+    .header-grid {
+      display: grid;
+      grid-template-columns: auto auto 1fr;
+      gap: 0 1rem;
+    }
+
+    .table-invoice {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid;
+      table-layout: fixed;
+    }
+
+    .table-invoice th,
+    .table-invoice td {
+      padding: 0.5em 1em;
+      background-color: white;
+    }
+
+    .table-invoice tbody th,
+    .table-invoice tbody td {
+      border-top: 1px solid;
+      border-color: inherit;
+    }
+
+    .table-invoice tbody tr:last-child td {
+      border-bottom: 1px solid;
+      border-color: inherit;
+    }
+
+    img.header-logo {
+      max-height: 72px;
+      max-width: 160px;
+    }
+
+    footer {
+      margin-top: 100px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="v-application theme--light">
+    <div class="container text-body-2">
+      <header>
+        <div class="d-flex justify-space-between">
+          <div>
+            <p class="text-h6">
+              <strong>Invoice #{{ data.booking_id }}</strong>
+            </p>
+            {% if data.issue_data and data.issue_data.issue_id %}
+            <div>
+              {{ data.issue_data.subject }} ({{ data.issue_data.status }})
+            </div>
+            {% endif %}
+            <div class="mt-4 header-grid">
+              <div>Tanggal Invoice</div>
+              <span>:</span>
+              <p><strong>{{udf_pretty_date(data.created_date, include_year=True)}}</strong></p>
+
+              <div>Jatuh Tempo</div>
+              <span>:</span>
+              <p><strong>{{udf_pretty_date(data.created_date, include_year=True)}}</strong></p>
+
+              <div>Pembayaran</div>
+              <span>:</span>
+              <p><strong>CREDIT</strong></p>
+            </div>
+          </div>
+          <div class="text-right">
+            {% if header and header.logo_src %}
+            <img
+              src="{{ header.logo_src }}"
+              class="header-logo"
+            >
+            {% endif %}
+          </div>
+        </div>
+      </header>
+
+      <main class="mt-8">
+        <div class="font-weight-bold">
+          CUSTOMER: {{ data.on_behalf_user_account_name }}
+        </div>
+
+        <table class="table-invoice table-fixed grey lighten-2 mt-2">
+          <thead>
+            <tr class="text-left">
+              <th style="width: 10px !important">No</th>
+              <th>Nama Produk</th>
+              <th style="width: 30% !important">Detail Produk</th>
+              <th class="text-center">Kuantitas</th>
+              <th class="text-right">Jumlah IDR</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in data.guest_order_data.order_data %}
+            <tr>
+              <td class="text-right">{{loop.index}}</td>
+              <td class="text-capitalize">{{item.item_name}}</td>
+              <td>{{item.item_detail}}</td>
+              <td class="text-center">{{item.quantity}}</td>
+              <td class="text-right text-no-wrap">{{udf_format_currency(item.price)}}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+          <tfoot>
+            {% for price_data in price_breakdown %}
+            <tr>
+              {% if price_data.type_code != 'BO' %}
+              <td colspan="3"></td>
+              <td class="text-center">
+                {{price_data.type_description}} {{price_data.note}}
+              </td>
+              <td class="text-right text-no-wrap">{{udf_format_currency(price_data.amount)}}</td>
+              {% endif %}
+            </tr>
+            {% endfor %}
+            <tr class="font-weight-bold">
+              <td colspan="3"></td>
+              <td class="text-center">Total</td>
+              <td class="text-right text-no-wrap">{{udf_format_currency(data.final_price) }}</td>
+            </tr>
+          </tfoot>
+        </table>
+
+        <div class="mt-8">
+          <div class="d-flex align-end">
+            <p>
+              Rekening BCA<br>
+              AN. PT WISATA JAWA INDAH<br>
+              AC. 829.090.8770
+            </p>
+            <i class="spacer"></i>
+            <div class="mr-6">
+              {{data.created_by}}
+            </div>
+            <div class="mr-6 text-center">
+              <p class="mb-12">Diterima oleh,</p>
+              <span>(______________)</span>
+            </div>
+            <div class="mr-6 text-center">
+              <p class="mb-12">Disetujui oleh,</p>
+              <span>(______________)</span>
+            </div>
+          </div>
+        </div>
+      </main>
+      
+      {% include 'footer.html' %}
+    </div>
+  </div>
+
+</body>
+
+</html>


### PR DESCRIPTION
### How to Test

1. Open chrome > chrome web inspector > network
2. Open https://project-exterior.com/, login as backoffice
3. Go to `/booking` page, choose one of offline custom booking
4. In `/booking/_id` page, try printing the offline custom booking invoice
5. In network inspector, copy and paste the `context` value from the `/api/print` API call to the template below

    ```json
    {
      "type": "offline-booking-custom-invoice",
      "format": "pdf",
      "filename": "Offline Booking Custom Invoice",
      "header": {
        "logo_src": "https://cdn.wisata.app/f/52ee9453-c8c7-452d-9457-7674df571c8f.jpeg",
        "logo_alt": ""
      },
      "footer": {
        "show_download_app": true
      },
     "data": {/*Copy to here*/}
    }
    ```
6. Make request to `http://localhost:8000/print` with the payload above
7. Compare invoice from project-exterior and this project

### Preview

Example: https://project-exterior.com/booking/829665


| project-exterior | this project |
| --- | --- |
| <img width="447" alt="image" src="https://github.com/amardevsingh98/python-html-to-pdf/assets/74803142/d6fe1249-a64d-4ff7-ba94-43c647d716f1"> | <img width="899" alt="image" src="https://github.com/amardevsingh98/python-html-to-pdf/assets/74803142/7c2541dc-75de-4f24-804b-87b6104cf801"> |

